### PR TITLE
Implement Diesel repository traits

### DIFF
--- a/src/models/email.rs
+++ b/src/models/email.rs
@@ -61,3 +61,38 @@ pub struct NewEmailRecipient<'a> {
     pub is_sent: bool,
     pub replied: bool,
 }
+
+use crate::domain::email as domain;
+
+impl From<Email> for domain::Email {
+    fn from(value: Email) -> Self {
+        Self {
+            id: value.id,
+            message: value.message,
+            created_at: value.created_at,
+            is_sent: value.is_sent,
+            subject: value.subject,
+            attachment: value.attachment,
+            attachment_name: value.attachment_name,
+            attachment_mime: value.attachment_mime,
+            num_sent: value.num_sent,
+            num_opened: value.num_opened,
+            num_replied: value.num_replied,
+            hub_id: value.hub_id,
+        }
+    }
+}
+
+impl From<EmailRecipient> for domain::EmailRecipient {
+    fn from(value: EmailRecipient) -> Self {
+        Self {
+            id: value.id,
+            email_id: value.email_id,
+            address: value.address,
+            opened: value.opened,
+            updated_at: value.updated_at,
+            is_sent: value.is_sent,
+            replied: value.replied,
+        }
+    }
+}

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -34,3 +34,17 @@ pub struct GroupRecipient {
     pub group_id: i32,
     pub recipient_id: i32,
 }
+
+use crate::domain::group as domain;
+
+impl From<Group> for domain::Group {
+    fn from(value: Group) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            hub_id: value.hub_id,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        }
+    }
+}

--- a/src/models/recipient.rs
+++ b/src/models/recipient.rs
@@ -36,3 +36,20 @@ pub struct RecipientField {
     pub field: String,
     pub value: String,
 }
+
+use crate::domain::recipient as domain;
+
+impl From<Recipient> for domain::Recipient {
+    fn from(value: Recipient) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            email: value.email,
+            hub_id: value.hub_id,
+            fields: std::collections::HashMap::new(),
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            unsubscribed_at: value.unsubscribed_at,
+        }
+    }
+}

--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -23,8 +23,214 @@ impl<'a> DieselEmailRepository<'a> {
     }
 }
 
-impl EmailReader for DieselEmailRepository<'_> {}
-impl EmailWriter for DieselEmailRepository<'_> {}
+use crate::domain::email::{EmailWithRecipients as DomainEmailWithRecipients, NewEmail as DomainNewEmail, UpdateEmail as DomainUpdateEmail, UpdateEmailRecipient as DomainUpdateEmailRecipient};
+use crate::repository::errors::RepositoryError;
+
+impl EmailReader for DieselEmailRepository<'_> {
+    fn get_by_id(&self, id: i32) -> RepositoryResult<Option<DomainEmailWithRecipients>> {
+        use crate::schema::{email_recipients, emails};
+        let mut conn = self.pool.get()?;
+
+        let email = emails::table
+            .filter(emails::id.eq(id))
+            .select(Email::as_select())
+            .first::<Email>(&mut conn)
+            .optional()?;
+
+        if let Some(email) = email {
+            let recipients = email_recipients::table
+                .filter(email_recipients::email_id.eq(email.id))
+                .select(EmailRecipient::as_select())
+                .load::<EmailRecipient>(&mut conn)?;
+
+            Ok(Some(DomainEmailWithRecipients {
+                email: email.into(),
+                recipients: recipients.into_iter().map(Into::into).collect(),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn list(&self, hub_id: i32) -> RepositoryResult<Vec<DomainEmailWithRecipients>> {
+        use crate::schema::emails;
+        let mut conn = self.pool.get()?;
+
+        let db_emails: Vec<Email> = emails::table
+            .filter(emails::hub_id.eq(hub_id))
+            .order(emails::created_at.desc())
+            .select(Email::as_select())
+            .load(&mut conn)?;
+
+        if db_emails.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let db_recipients: Vec<EmailRecipient> = EmailRecipient::belonging_to(&db_emails)
+            .select(EmailRecipient::as_select())
+            .load(&mut conn)?;
+
+        let grouped = db_recipients.grouped_by(&db_emails);
+
+        Ok(db_emails
+            .into_iter()
+            .zip(grouped)
+            .map(|(email, recipients)| DomainEmailWithRecipients {
+                email: email.into(),
+                recipients: recipients.into_iter().map(Into::into).collect(),
+            })
+            .collect())
+    }
+}
+
+impl EmailWriter for DieselEmailRepository<'_> {
+    fn create(&self, email: &DomainNewEmail) -> RepositoryResult<DomainEmailWithRecipients> {
+        use crate::schema::{email_recipients, emails, groups_recipients, recipients as rec};
+        let mut conn = self.pool.get()?;
+
+        conn.transaction::<_, RepositoryError, _>(|conn| {
+            let created_at = chrono::Utc::now().naive_utc();
+            let new_email = NewEmail {
+                message: email.message,
+                created_at: &created_at,
+                is_sent: false,
+                subject: email.subject,
+                attachment: email.attachment,
+                attachment_name: email.attachment_name,
+                attachment_mime: email.attachment_mime,
+                hub_id: email.hub_id,
+            };
+
+            let inserted: Email = diesel::insert_into(emails::table)
+                .values(&new_email)
+                .get_result(conn)?;
+
+            for item in &email.recipients {
+                if item.contains('@') {
+                    let r: Recipient = rec::table
+                        .filter(rec::email.eq(item.trim()))
+                        .filter(rec::unsubscribed_at.is_null())
+                        .select(Recipient::as_select())
+                        .first(conn)?;
+
+                    let new_rec = NewEmailRecipient {
+                        email_id: inserted.id,
+                        address: &r.email,
+                        opened: false,
+                        updated_at: &created_at,
+                        is_sent: false,
+                        replied: false,
+                    };
+                    diesel::insert_into(email_recipients::table)
+                        .values(&new_rec)
+                        .execute(conn)?;
+                } else {
+                    let group_id: i32 = item
+                        .parse()
+                        .map_err(|_| RepositoryError::ValidationError("invalid group id".into()))?;
+
+                    let members: Vec<Recipient> = groups_recipients::table
+                        .filter(groups_recipients::group_id.eq(group_id))
+                        .inner_join(rec::table.on(groups_recipients::recipient_id.eq(rec::id)))
+                        .select(Recipient::as_select())
+                        .load(conn)?;
+
+                    for member in members {
+                        let new_rec = NewEmailRecipient {
+                            email_id: inserted.id,
+                            address: &member.email,
+                            opened: false,
+                            updated_at: &created_at,
+                            is_sent: false,
+                            replied: false,
+                        };
+                        diesel::insert_into(email_recipients::table)
+                            .values(&new_rec)
+                            .execute(conn)?;
+                    }
+                }
+            }
+
+            let recipients = email_recipients::table
+                .filter(email_recipients::email_id.eq(inserted.id))
+                .select(EmailRecipient::as_select())
+                .load::<EmailRecipient>(conn)?;
+
+            Ok(DomainEmailWithRecipients {
+                email: inserted.into(),
+                recipients: recipients.into_iter().map(Into::into).collect(),
+            })
+        })
+    }
+
+    fn update(&self, email_id: i32, updates: &DomainUpdateEmail) -> RepositoryResult<DomainEmailWithRecipients> {
+        use crate::schema::emails::dsl as emails;
+        let mut conn = self.pool.get()?;
+        diesel::update(emails::emails.filter(emails::id.eq(email_id)))
+            .set((
+                emails::num_sent.eq(updates.num_sent),
+                emails::num_opened.eq(updates.num_opened),
+                emails::num_replied.eq(updates.num_replied),
+            ))
+            .execute(&mut conn)?;
+
+        let email = emails::emails
+            .filter(emails::id.eq(email_id))
+            .select(Email::as_select())
+            .first::<Email>(&mut conn)?;
+
+        let recipients = EmailRecipient::belonging_to(&email)
+            .select(EmailRecipient::as_select())
+            .load::<EmailRecipient>(&mut conn)?;
+
+        Ok(DomainEmailWithRecipients {
+            email: email.into(),
+            recipients: recipients.into_iter().map(Into::into).collect(),
+        })
+    }
+
+    fn update_recipient(&self, recipient_id: i32, updates: &DomainUpdateEmailRecipient) -> RepositoryResult<DomainEmailWithRecipients> {
+        use crate::schema::email_recipients::dsl as er;
+        let mut conn = self.pool.get()?;
+        let email_id: i32 = er::email_recipients
+            .filter(er::id.eq(recipient_id))
+            .select(er::email_id)
+            .first(&mut conn)?;
+
+        diesel::update(er::email_recipients.filter(er::id.eq(recipient_id)))
+            .set((
+                er::opened.eq(updates.opened),
+                er::is_sent.eq(updates.is_sent),
+                er::replied.eq(updates.replied),
+                er::updated_at.eq(chrono::Utc::now().naive_utc()),
+            ))
+            .execute(&mut conn)?;
+
+        use crate::schema::emails::dsl as emails;
+
+        let email = emails::emails
+            .filter(emails::id.eq(email_id))
+            .select(Email::as_select())
+            .first::<Email>(&mut conn)?;
+
+        let recipients = EmailRecipient::belonging_to(&email)
+            .select(EmailRecipient::as_select())
+            .load::<EmailRecipient>(&mut conn)?;
+
+        Ok(DomainEmailWithRecipients {
+            email: email.into(),
+            recipients: recipients.into_iter().map(Into::into).collect(),
+        })
+    }
+
+    fn delete(&self, id: i32) -> RepositoryResult<()> {
+        use crate::schema::{email_recipients, emails};
+        let mut conn = self.pool.get()?;
+        diesel::delete(email_recipients::table.filter(email_recipients::email_id.eq(id))).execute(&mut conn)?;
+        diesel::delete(emails::table.filter(emails::id.eq(id))).execute(&mut conn)?;
+        Ok(())
+    }
+}
 
 pub fn get_hub_all_emails_with_recipients(
     conn: &mut SqliteConnection,

--- a/src/repository/group.rs
+++ b/src/repository/group.rs
@@ -1,3 +1,12 @@
+use diesel::prelude::*;
+use pushkind_common::db::DbPool;
+
+use crate::domain::group::{Group as DomainGroup, GroupWithRecipients, NewGroup as DomainNewGroup};
+use crate::models::group::{Group as DbGroup, GroupRecipient, NewGroup as DbNewGroup};
+use crate::models::recipient::Recipient as DbRecipient;
+use crate::repository::errors::RepositoryResult;
+use crate::repository::{GroupReader, GroupWriter};
+
 /// Diesel implementation of [`GroupRepository`].
 pub struct DieselGroupRepository<'a> {
     pool: &'a DbPool,
@@ -9,5 +18,67 @@ impl<'a> DieselGroupRepository<'a> {
     }
 }
 
-impl GroupReader for DieselGroupRepository<'_> {}
-impl GroupWriter for DieselGroupRepository<'_> {}
+impl GroupReader for DieselGroupRepository<'_> {
+    fn list(&self, hub_id: i32) -> RepositoryResult<Vec<GroupWithRecipients>> {
+        use crate::schema::{groups, groups_recipients, recipients};
+        let mut conn = self.pool.get()?;
+
+        // Fetch groups for hub
+        let db_groups: Vec<DbGroup> = groups::table
+            .filter(groups::hub_id.eq(hub_id))
+            .select(DbGroup::as_select())
+            .load(&mut conn)?;
+
+        if db_groups.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Fetch recipients for groups
+        let group_recipients: Vec<(GroupRecipient, DbRecipient)> = groups_recipients::table
+            .filter(groups_recipients::group_id.eq_any(db_groups.iter().map(|g| g.id)))
+            .inner_join(recipients::table)
+            .select((GroupRecipient::as_select(), DbRecipient::as_select()))
+            .load(&mut conn)?;
+
+        use std::collections::HashMap;
+        let mut map: HashMap<i32, Vec<DbRecipient>> = HashMap::new();
+        for (gr, rec) in group_recipients {
+            map.entry(gr.group_id).or_default().push(rec);
+        }
+
+        Ok(db_groups
+            .into_iter()
+            .map(|g| {
+                let recipients = map
+                    .remove(&g.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|r| r.into())
+                    .collect();
+                GroupWithRecipients {
+                    group: DomainGroup::from(g),
+                    recipients,
+                }
+            })
+            .collect())
+    }
+}
+
+impl GroupWriter for DieselGroupRepository<'_> {
+    fn create(&self, group: &DomainNewGroup) -> RepositoryResult<DomainGroup> {
+        use crate::schema::groups;
+        let mut conn = self.pool.get()?;
+        let db_new = DbNewGroup { name: group.name, hub_id: group.hub_id };
+        let inserted = diesel::insert_into(groups::table)
+            .values(&db_new)
+            .get_result::<DbGroup>(&mut conn)?;
+        Ok(inserted.into())
+    }
+
+    fn delete(&self, id: i32) -> RepositoryResult<()> {
+        use crate::schema::groups;
+        let mut conn = self.pool.get()?;
+        diesel::delete(groups::table.filter(groups::id.eq(id))).execute(&mut conn)?;
+        Ok(())
+    }
+}

--- a/src/repository/recipient.rs
+++ b/src/repository/recipient.rs
@@ -7,8 +7,9 @@ use serde::Deserialize;
 
 use crate::models::group::{Group, GroupRecipient, NewGroup};
 use crate::models::recipient::{NewRecipient, Recipient, RecipientField};
-use crate::repository::errors::RepositoryResult;
+use crate::repository::errors::{RepositoryError, RepositoryResult};
 use crate::repository::{RecipientReader, RecipientWriter};
+use crate::domain::recipient::{NewRecipient as DomainNewRecipient, Recipient as DomainRecipient, RecipientWithGroups, UpdateRecipient as DomainUpdateRecipient};
 
 /// Diesel implementation of [`RecipientRepository`].
 pub struct DieselRecipientRepository<'a> {
@@ -21,8 +22,152 @@ impl<'a> DieselRecipientRepository<'a> {
     }
 }
 
-impl RecipientReader for DieselRecipientRepository<'_> {}
-impl RecipientWriter for DieselRecipientRepository<'_> {}
+impl RecipientReader for DieselRecipientRepository<'_> {
+    fn list(&self, hub_id: i32) -> RepositoryResult<Vec<RecipientWithGroups>> {
+        use crate::schema::{groups, recipients};
+        let mut conn = self.pool.get()?;
+
+        // Load recipients for hub
+        let db_recipients: Vec<Recipient> = recipients::table
+            .filter(recipients::hub_id.eq(hub_id))
+            .select(Recipient::as_select())
+            .order(recipients::name.desc())
+            .load(&mut conn)?;
+
+        if db_recipients.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Load recipient fields
+        let db_fields = RecipientField::belonging_to(&db_recipients)
+            .select(RecipientField::as_select())
+            .load::<RecipientField>(&mut conn)?
+            .grouped_by(&db_recipients);
+
+        // Load group-recipient relations
+        let db_group_recipients = GroupRecipient::belonging_to(&db_recipients)
+            .select(GroupRecipient::as_select())
+            .load::<GroupRecipient>(&mut conn)?;
+
+        // Fetch all groups referenced
+        let group_ids: HashSet<i32> = db_group_recipients.iter().map(|gr| gr.group_id).collect();
+
+        let db_groups: Vec<Group> = groups::table
+            .filter(groups::id.eq_any(&group_ids))
+            .select(Group::as_select())
+            .load(&mut conn)?;
+
+        let group_map: HashMap<i32, Group> = db_groups.into_iter().map(|g| (g.id, g)).collect();
+
+        let mut recipient_groups: HashMap<i32, Vec<Group>> = HashMap::new();
+        for gr in db_group_recipients {
+            if let Some(g) = group_map.get(&gr.group_id) {
+                recipient_groups.entry(gr.recipient_id).or_default().push(g.clone());
+            }
+        }
+
+        Ok(db_recipients
+            .into_iter()
+            .zip(db_fields.into_iter())
+            .map(|(rec, fields)| {
+                let field_map = fields.into_iter().map(|f| (f.field, f.value)).collect();
+                let groups = recipient_groups.remove(&rec.id).unwrap_or_default();
+                let recipient = DomainRecipient {
+                    id: rec.id,
+                    name: rec.name,
+                    email: rec.email,
+                    hub_id: rec.hub_id,
+                    fields: field_map,
+                    created_at: rec.created_at,
+                    updated_at: rec.updated_at,
+                    unsubscribed_at: rec.unsubscribed_at,
+                };
+                RecipientWithGroups {
+                    recipient,
+                    groups: groups.into_iter().map(Into::into).collect(),
+                }
+            })
+            .collect())
+    }
+}
+
+impl RecipientWriter for DieselRecipientRepository<'_> {
+    fn create(&self, recipient: &[DomainNewRecipient]) -> RepositoryResult<DomainRecipient> {
+        use crate::schema::recipients;
+        let mut conn = self.pool.get()?;
+        let new = recipient
+            .first()
+            .ok_or_else(|| RepositoryError::ValidationError("empty slice".into()))?;
+        let db_new = NewRecipient { name: new.name, email: new.email, hub_id: new.hub_id };
+        let inserted = diesel::insert_into(recipients::table)
+            .values(&db_new)
+            .get_result::<Recipient>(&mut conn)?;
+        Ok(DomainRecipient {
+            id: inserted.id,
+            name: inserted.name,
+            email: inserted.email,
+            hub_id: inserted.hub_id,
+            fields: HashMap::new(),
+            created_at: inserted.created_at,
+            updated_at: inserted.updated_at,
+            unsubscribed_at: inserted.unsubscribed_at,
+        })
+    }
+
+    fn update(&self, id: i32, recipient: &DomainUpdateRecipient) -> RepositoryResult<DomainRecipient> {
+        use crate::schema::{recipient_fields, recipients};
+        let mut conn = self.pool.get()?;
+
+        diesel::update(recipients::table.filter(recipients::id.eq(id)))
+            .set((
+                recipients::name.eq(recipient.name),
+                recipients::email.eq(recipient.email),
+                recipients::unsubscribed_at.eq(recipient.unsubscribed_at),
+            ))
+            .execute(&mut conn)?;
+
+        diesel::delete(recipient_fields::table.filter(recipient_fields::recipient_id.eq(id))).execute(&mut conn)?;
+        for (field, value) in recipient.fields {
+            let new_field = RecipientField { recipient_id: id, field: field.clone(), value: value.clone() };
+            diesel::insert_into(recipient_fields::table)
+                .values(&new_field)
+                .execute(&mut conn)?;
+        }
+
+        let rec = recipients::table
+            .filter(recipients::id.eq(id))
+            .select(Recipient::as_select())
+            .first::<Recipient>(&mut conn)?;
+
+        let fields_vec = recipient_fields::table
+            .filter(recipient_fields::recipient_id.eq(id))
+            .select(RecipientField::as_select())
+            .load::<RecipientField>(&mut conn)?;
+
+        let mut fields_map = HashMap::new();
+        for f in fields_vec {
+            fields_map.insert(f.field, f.value);
+        }
+
+        Ok(DomainRecipient {
+            id: rec.id,
+            name: rec.name,
+            email: rec.email,
+            hub_id: rec.hub_id,
+            fields: fields_map,
+            created_at: rec.created_at,
+            updated_at: rec.updated_at,
+            unsubscribed_at: rec.unsubscribed_at,
+        })
+    }
+
+    fn delete(&self, id: i32) -> RepositoryResult<()> {
+        use crate::schema::recipients::dsl as recipients;
+        let mut conn = self.pool.get()?;
+        diesel::delete(recipients::recipients.filter(recipients::id.eq(id))).execute(&mut conn)?;
+        Ok(())
+    }
+}
 
 pub fn get_hub_all_recipients(
     conn: &mut SqliteConnection,


### PR DESCRIPTION
## Summary
- finish Diesel repository logic without helper functions
- convert DB models to domain models
- fully implement recipient listing

## Testing
- `cargo check --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6880c89c3a24832fa7f9c15b9f88beeb