### PR TITLE
Fix unsubscribe URL method

### DIFF
--- a/src/bin/send_email.rs
+++ b/src/bin/send_email.rs
@@ -25,7 +25,7 @@ async fn send_smtp_message(
 ) -> Result<(), mail_send::Error> {
     let template = hub.email_template.as_deref().unwrap_or_default();
 
-    let unsubscribe_url = hub.get_usubscribe_url();
+    let unsubscribe_url = hub.get_unsubscribe_url();
     let mut body: String;
 
     let template = template.replace("{unsubscribe_url}", &unsubscribe_url);

--- a/src/domain/hub.rs
+++ b/src/domain/hub.rs
@@ -44,7 +44,12 @@ pub struct UpdateHub<'a> {
 }
 
 impl Hub {
-    pub fn get_usubscribe_url(&self) -> String {
+    /// Generates a `mailto:` link to unsubscribe from emails.
+    ///
+    /// If the hub has a login configured, the returned URL is of the form
+    /// `mailto:<login>?subject=unsubscribe`. Otherwise an empty string is
+    /// returned.
+    pub fn get_unsubscribe_url(&self) -> String {
         match &self.login {
             Some(login) => format!("mailto:{login}?subject=unsubscribe"),
             None => String::from(""),


### PR DESCRIPTION
## Summary
- rename `get_usubscribe_url` to `get_unsubscribe_url`
- update email worker to use new method
- add doc comment about the returned mailto link

## Testing
- `cargo check --all-targets --all-features`

------
https://chatgpt.com/codex/tasks/task_e_6882681a2644832f85f331210d7dfe97