### PR TITLE
Fix log message in template render helper

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -22,7 +22,7 @@ lazy_static! {
 
 fn render_template(template: &str, context: &Context) -> HttpResponse {
     HttpResponse::Ok().body(TEMPLATES.render(template, context).unwrap_or_else(|e| {
-        error!("Failed to render template {template}': {e}");
+        error!("Failed to render template {template}: {e}");
         String::new()
     }))
 }


### PR DESCRIPTION
## Summary
- fix typo in template render error log

## Testing
- `cargo clippy`
- `cargo test --all-targets --all-features`

------
https://chatgpt.com/codex/tasks/task_e_688274137f5c832f8af82d8df3c7a605