### PR TITLE
Remove unused group_ids tracking

### DIFF
--- a/src/repository/recipient.rs
+++ b/src/repository/recipient.rs
@@ -178,7 +178,6 @@ impl RecipientWriter for DieselRecipientRepository<'_> {
                 }
 
                 // Create and assign groups
-                let mut group_ids = Vec::new();
                 if let Some(names) = &new.groups {
                     for group_name in names {
                         // Check if group already exists
@@ -201,8 +200,6 @@ impl RecipientWriter for DieselRecipientRepository<'_> {
                                     .get_result::<Group>(conn)?
                             }
                         };
-
-                        group_ids.push(group.id);
 
                         let link = GroupRecipient {
                             group_id: group.id,


### PR DESCRIPTION
## Summary
- delete the temporary `group_ids` vector and push call in recipient creation

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6882787848dc832fa2fd857517b164c7