### PR TITLE
Add documentation comments to domain structs

### DIFF
--- a/src/domain/email.rs
+++ b/src/domain/email.rs
@@ -2,56 +2,96 @@ use chrono::NaiveDateTime;
 use serde::Serialize;
 
 #[derive(Serialize)]
+/// An email message stored in the system.
 pub struct Email {
+    /// Database identifier of the email.
     pub id: i32,
+    /// Raw body of the message that will be sent to recipients.
     pub message: String,
+    /// Time the email record was created.
     pub created_at: NaiveDateTime,
+    /// Whether the email has already been sent.
     pub is_sent: bool,
+    /// Optional subject line for the message.
     pub subject: Option<String>,
+    /// Optional binary attachment.
     pub attachment: Option<Vec<u8>>,
+    /// File name of the attachment, if any.
     pub attachment_name: Option<String>,
+    /// MIME type of the attachment.
     pub attachment_mime: Option<String>,
+    /// Number of recipients the email was sent to.
     pub num_sent: i32,
+    /// Number of recipients that opened the email.
     pub num_opened: i32,
+    /// Number of recipients that replied to the email.
     pub num_replied: i32,
+    /// Hub that owns this email.
     pub hub_id: i32,
 }
 
 #[derive(Serialize)]
+/// A single email address targeted by an email.
 pub struct EmailRecipient {
+    /// Identifier of the record.
     pub id: i32,
+    /// Associated [`Email`] id.
     pub email_id: i32,
+    /// Recipient email address.
     pub address: String,
+    /// Whether the message was opened by the recipient.
     pub opened: bool,
+    /// Last time the recipient record was updated.
     pub updated_at: NaiveDateTime,
+    /// Flag indicating the email was sent to this recipient.
     pub is_sent: bool,
+    /// Whether the recipient replied.
     pub replied: bool,
 }
 
 #[derive(Serialize)]
+/// A convenience wrapper containing an email and its recipients.
 pub struct EmailWithRecipients {
+    /// The email message.
     pub email: Email,
+    /// Recipients of the email.
     pub recipients: Vec<EmailRecipient>,
 }
 
+/// Parameters required to create a new [`Email`].
 pub struct NewEmail {
+    /// Body of the message to be sent.
     pub message: String,
+    /// Optional subject line.
     pub subject: Option<String>,
+    /// Optional binary attachment for the email.
     pub attachment: Option<Vec<u8>>,
+    /// Name of the attachment file.
     pub attachment_name: Option<String>,
+    /// MIME type of the attachment.
     pub attachment_mime: Option<String>,
+    /// Hub to which the email belongs.
     pub hub_id: i32,
+    /// List of recipient email addresses.
     pub recipients: Vec<String>,
 }
 
+/// Counters used to update email statistics.
 pub struct UpdateEmail {
+    /// Total number of times the email was sent.
     pub num_sent: i32,
+    /// How many recipients opened the email.
     pub num_opened: i32,
+    /// How many recipients replied to the email.
     pub num_replied: i32,
 }
 
+/// Changes to apply to an [`EmailRecipient`] record.
 pub struct UpdateEmailRecipient {
+    /// Updated open status.
     pub opened: Option<bool>,
+    /// Updated sent status.
     pub is_sent: Option<bool>,
+    /// Updated reply status.
     pub replied: Option<bool>,
 }

--- a/src/domain/group.rs
+++ b/src/domain/group.rs
@@ -4,21 +4,33 @@ use serde::Serialize;
 use crate::domain::recipient::Recipient;
 
 #[derive(Serialize)]
+/// A named collection of recipients within a hub.
 pub struct Group {
+    /// Identifier of the group.
     pub id: i32,
+    /// Display name of the group.
     pub name: String,
+    /// Hub that owns the group.
     pub hub_id: i32,
+    /// Time the group was created.
     pub created_at: Option<NaiveDateTime>,
+    /// Last modification time of the group.
     pub updated_at: Option<NaiveDateTime>,
 }
 
 #[derive(Serialize)]
+/// A group together with all of its recipients.
 pub struct GroupWithRecipients {
+    /// The group metadata.
     pub group: Group,
+    /// Recipients belonging to the group.
     pub recipients: Vec<Recipient>,
 }
 
+/// Parameters to create a new [`Group`].
 pub struct NewGroup<'a> {
+    /// Name of the group.
     pub name: &'a str,
+    /// Hub that will own the group.
     pub hub_id: i32,
 }

--- a/src/domain/hub.rs
+++ b/src/domain/hub.rs
@@ -2,44 +2,79 @@ use chrono::NaiveDateTime;
 use serde::Serialize;
 
 #[derive(Serialize)]
+/// Configuration and metadata for an email hub.
 pub struct Hub {
+    /// Identifier of the hub.
     pub id: i32,
+    /// Optional login used for sending emails.
     pub login: Option<String>,
+    /// Optional password for the login.
     pub password: Option<String>,
+    /// Sender address that appears in outgoing emails.
     pub sender: Option<String>,
+    /// SMTP server hostname.
     pub smtp_server: Option<String>,
+    /// SMTP server port.
     pub smtp_port: Option<i32>,
+    /// When the hub was created.
     pub created_at: Option<NaiveDateTime>,
+    /// When the hub settings were last updated.
     pub updated_at: Option<NaiveDateTime>,
+    /// IMAP server hostname for reading replies.
     pub imap_server: Option<String>,
+    /// IMAP server port.
     pub imap_port: Option<i32>,
+    /// Template applied to outgoing emails.
     pub email_template: Option<String>,
 }
 
+/// Data required to create a new [`Hub`].
 pub struct NewHub<'a> {
+    /// Identifier of the hub to be created.
     pub id: i32,
+    /// Login used for SMTP authentication.
     pub login: Option<&'a str>,
+    /// Password for the SMTP login.
     pub password: Option<&'a str>,
+    /// Sender address used in outgoing emails.
     pub sender: Option<&'a str>,
+    /// SMTP server hostname.
     pub smtp_server: Option<&'a str>,
+    /// SMTP server port.
     pub smtp_port: Option<i32>,
+    /// Creation timestamp.
     pub created_at: Option<NaiveDateTime>,
+    /// Last update timestamp.
     pub updated_at: Option<NaiveDateTime>,
+    /// IMAP server hostname.
     pub imap_server: Option<&'a str>,
+    /// IMAP server port.
     pub imap_port: Option<i32>,
+    /// Template applied to outgoing emails.
     pub email_template: Option<&'a str>,
 }
 
+/// Fields that can be updated for an existing [`Hub`].
 pub struct UpdateHub<'a> {
+    /// New login for SMTP authentication.
     pub login: Option<&'a str>,
+    /// New password for the login.
     pub password: Option<&'a str>,
+    /// Updated sender address.
     pub sender: Option<&'a str>,
+    /// Updated SMTP server hostname.
     pub smtp_server: Option<&'a str>,
+    /// Updated SMTP port.
     pub smtp_port: Option<i32>,
+    /// Updated creation timestamp.
     pub created_at: Option<NaiveDateTime>,
+    /// Updated modification timestamp.
     pub updated_at: Option<NaiveDateTime>,
+    /// Updated IMAP server hostname.
     pub imap_server: Option<&'a str>,
+    /// Updated IMAP port.
     pub imap_port: Option<i32>,
+    /// Updated email template.
     pub email_template: Option<&'a str>,
 }
 

--- a/src/domain/recipient.rs
+++ b/src/domain/recipient.rs
@@ -6,36 +6,61 @@ use serde::Serialize;
 use crate::domain::group::Group;
 
 #[derive(Serialize)]
+/// An individual that can receive emails from a hub.
 pub struct Recipient {
+    /// Database identifier of the recipient.
     pub id: i32,
+    /// Human readable name.
     pub name: String,
+    /// Email address used for deliveries.
     pub email: String,
+    /// Hub this recipient belongs to.
     pub hub_id: i32,
+    /// Additional custom fields associated with the recipient.
     pub fields: HashMap<String, String>,
+    /// Time the recipient was created.
     pub created_at: Option<NaiveDateTime>,
+    /// Last modification time.
     pub updated_at: Option<NaiveDateTime>,
+    /// When the recipient unsubscribed, if applicable.
     pub unsubscribed_at: Option<NaiveDateTime>,
+    /// Groups to which the recipient belongs.
     pub groups: Vec<i32>,
 }
 
 #[derive(Serialize)]
+/// A recipient together with the groups they are a member of.
 pub struct RecipientWithGroups {
+    /// The recipient details.
     pub recipient: Recipient,
+    /// Groups associated with the recipient.
     pub groups: Vec<Group>,
 }
 
+/// Data required to create a new [`Recipient`].
 pub struct NewRecipient {
+    /// Name of the recipient.
     pub name: String,
+    /// Email address.
     pub email: String,
+    /// Hub to associate with the recipient.
     pub hub_id: i32,
+    /// Optional set of custom fields.
     pub fields: Option<HashMap<String, String>>,
+    /// Optional list of group names to subscribe the recipient to.
     pub groups: Option<Vec<String>>,
 }
 
+/// Fields that can be modified for an existing [`Recipient`].
 pub struct UpdateRecipient {
+    /// Updated name.
     pub name: String,
+    /// Updated email address.
     pub email: String,
+    /// Updated map of custom fields.
     pub fields: HashMap<String, String>,
+    /// Timestamp when the recipient unsubscribed.
     pub unsubscribed_at: Option<NaiveDateTime>,
+    /// Groups the recipient should belong to.
     pub groups: Vec<i32>,
 }


### PR DESCRIPTION
## Summary
- document all public structs in the domain module
- describe struct fields for emails, recipients, groups and hubs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68827e4d01c8832f9a3b1128ca68f1d2