### PR TITLE
docs: improve comments and parsing

### DIFF
--- a/src/forms/files.rs
+++ b/src/forms/files.rs
@@ -1,5 +1,6 @@
 use actix_multipart::form::{MultipartForm, tempfile::TempFile};
 
+/// Form used to upload a single file via multipart request.
 #[derive(MultipartForm)]
 pub struct UploadFileForm {
     #[multipart(limit = "10MB")]

--- a/src/forms/groups.rs
+++ b/src/forms/groups.rs
@@ -1,17 +1,20 @@
 use serde::Deserialize;
 use validator::Validate;
 
+/// Form data for creating a new recipient group.
 #[derive(Deserialize, Validate)]
 pub struct AddGroupForm {
     #[validate(length(min = 1))]
     pub name: String,
 }
 
+/// Form data to delete an existing group by identifier.
 #[derive(Deserialize)]
 pub struct DeleteGroupForm {
     pub id: i32,
 }
 
+/// Assigns a recipient to a group.
 #[derive(Deserialize)]
 pub struct AssignGroupRecipientForm {
     pub recipient_id: i32,

--- a/src/forms/main.rs
+++ b/src/forms/main.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 use crate::{domain::email::NewEmail, utils::read_attachment_file};
 
+/// Form data for sending a new email with optional attachment.
 #[derive(MultipartForm)]
 pub struct SendEmailForm {
     pub message: Text<String>,
@@ -12,12 +13,14 @@ pub struct SendEmailForm {
     pub recipients: MpJson<Vec<String>>,
 }
 
+/// Form data to remove an existing email.
 #[derive(Deserialize)]
 pub struct DeleteEmailForm {
     pub id: i32,
 }
 
 impl From<SendEmailForm> for NewEmail {
+    /// Converts a [`SendEmailForm`] into the domain [`NewEmail`] type.
     fn from(mut form: SendEmailForm) -> Self {
         let (attachment_name, attachment_mime, attachment) =
             if let Some(attachment) = form.attachment.as_mut() {

--- a/src/forms/mod.rs
+++ b/src/forms/mod.rs
@@ -1,3 +1,8 @@
+//! Web form types used by the application.
+//!
+//! Each submodule contains structs representing data submitted by the user via
+//! HTTP forms or multipart requests.
+
 pub mod files;
 pub mod groups;
 pub mod main;

--- a/src/forms/recipients.rs
+++ b/src/forms/recipients.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::io::Read;
 
 use actix_multipart::form::{MultipartForm, tempfile::TempFile};
-use csv;
 use reqwest::header::COOKIE;
 use serde::Deserialize;
 use thiserror::Error;
@@ -10,6 +9,7 @@ use validator::Validate;
 
 use crate::domain::recipient::{NewRecipient, UpdateRecipient};
 
+/// Form for adding a single recipient manually.
 #[derive(Deserialize, Validate)]
 pub struct AddRecipientForm {
     #[validate(length(min = 1))]
@@ -18,23 +18,27 @@ pub struct AddRecipientForm {
     pub email: String,
 }
 
+/// Form specifying an external source to load recipients from.
 #[derive(Deserialize, Validate)]
 pub struct SourceRecipientForm {
     #[validate(url)]
     pub source: String, // URL of the service to fetch a JSON array of NewRecipient
 }
 
+/// Form used to delete a recipient by identifier.
 #[derive(Deserialize)]
 pub struct DeleteRecipientForm {
     pub id: i32,
 }
 
+/// Form for uploading a CSV file containing recipients.
 #[derive(MultipartForm)]
 pub struct UploadRecipientsForm {
     #[multipart(limit = "10MB")]
     pub csv: TempFile,
 }
 
+/// Form data for updating an existing recipient.
 #[derive(Deserialize)]
 pub struct SaveRecipientForm {
     pub id: i32,
@@ -75,11 +79,12 @@ impl From<SaveRecipientForm> for UpdateRecipient {
     }
 }
 
+/// Errors that can occur while processing an uploaded CSV of recipients.
 #[derive(Debug, Error)]
 pub enum UploadRecipientsFormError {
-    #[error("Error reading csv file")]
+    #[error("Error reading CSV file")]
     FileReadError,
-    #[error("Error parsing csv file")]
+    #[error("Error parsing CSV file")]
     CsvParseError,
 }
 
@@ -144,6 +149,11 @@ impl UploadRecipientsForm {
                 }
             }
 
+            if name.trim().is_empty() || email.trim().is_empty() {
+                // Skip records missing required fields.
+                continue;
+            }
+
             recipients.push(NewRecipient {
                 name,
                 email,
@@ -169,11 +179,12 @@ impl From<AddRecipientForm> for NewRecipient {
     }
 }
 
+/// Errors returned when loading recipients from a remote service.
 #[derive(Debug, Error)]
 pub enum SourceRecipientFormError {
-    #[error("Error reading api")]
+    #[error("Error reading API")]
     RequestError,
-    #[error("Error parsing api")]
+    #[error("Error parsing API")]
     DeserializeError,
 }
 
@@ -184,6 +195,9 @@ impl From<reqwest::Error> for SourceRecipientFormError {
 }
 
 impl SourceRecipientForm {
+    /// Loads recipients from the external service specified in [`SourceRecipientForm`].
+    ///
+    /// The `id_value` is sent as a cookie named `id` with the request.
     pub async fn load(
         &self,
         id_value: &str,
@@ -191,7 +205,7 @@ impl SourceRecipientForm {
         let client = reqwest::Client::new();
         let response = client
             .get(&self.source)
-            .header(COOKIE, format!("id={}", id_value))
+            .header(COOKIE, format!("id={id_value}"))
             .send()
             .await?;
 

--- a/src/forms/settings.rs
+++ b/src/forms/settings.rs
@@ -2,16 +2,19 @@ use serde::Deserialize;
 
 use crate::domain::hub::UpdateHub;
 
+/// Form to create a new hub configuration.
 #[derive(Deserialize)]
 pub struct AddHubForm {
     pub hub_name: String,
 }
 
+/// Form to activate an existing hub by its identifier.
 #[derive(Deserialize)]
 pub struct ActivateHubForm {
     pub hub_id: i32,
 }
 
+/// Form for updating hub configuration details.
 #[derive(Deserialize)]
 pub struct SaveHubForm {
     pub id: i32,
@@ -43,6 +46,7 @@ impl<'a> From<&'a SaveHubForm> for UpdateHub<'a> {
     }
 }
 
+/// Form to remove a hub from the system.
 #[derive(Deserialize)]
 pub struct DeleteHubForm {
     pub id: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! Core library for the pushkind emailer application.
+//!
+//! This crate exposes the domain types, data models and utilities that power
+//! the pushkind emailer service.  The binary in [`main`](../main.rs) builds on
+//! top of these modules to provide an HTTP server and background workers.
+
 pub mod domain;
 pub mod forms;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+//! Binary that launches the HTTP server for the pushkind emailer application.
+
 use std::env;
 
 use actix_files::Files;
@@ -26,6 +28,7 @@ use pushkind_emailer::routes::recipients::{
 };
 use pushkind_emailer::routes::settings::{settings, settings_save};
 
+/// Application entry point launching the Actix Web server.
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));


### PR DESCRIPTION
## Summary
- document crate, server entry point, and various form structs
- improve CSV recipient upload parser and error messages
- add missing docs and comments across modules

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689b42777558832aa35205629b3e8229