### PR TITLE
Add CSV export route for email recipients

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ use pushkind_emailer::repository::DieselRepository;
 use pushkind_emailer::routes::groups::{
     groups, groups_add, groups_assign, groups_delete, groups_modal, groups_unassign,
 };
-use pushkind_emailer::routes::main::{delete_email, index, resend_email, send_email, track_email};
+use pushkind_emailer::routes::main::{
+    delete_email, export_email_recipients, index, resend_email, send_email, track_email,
+};
 use pushkind_emailer::routes::recipients::{
     recipients_add, recipients_clean, recipients_delete, recipients_modal, recipients_save,
     recipients_show, recipients_source, recipients_upload,
@@ -109,6 +111,7 @@ async fn main() -> std::io::Result<()> {
                     .service(resend_email)
                     .service(delete_email)
                     .service(track_email)
+                    .service(export_email_recipients)
                     .service(settings)
                     .service(settings_save)
                     .service(recipients_show)

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -201,3 +201,48 @@ pub async fn track_email(
 
     redirect("/assets/placeholder.png")
 }
+
+#[get("/emails/{email_id}/recipients/export")]
+pub async fn export_email_recipients(
+    user: AuthenticatedUser,
+    repo: web::Data<DieselRepository>,
+    email_id: web::Path<i32>,
+) -> impl Responder {
+    if let Err(response) = ensure_role(&user, "emailer", Some("/na")) {
+        return response;
+    };
+
+    let email_id = email_id.into_inner();
+    let email = match repo.get_email_by_id(email_id) {
+        Ok(Some(email)) if email.email.hub_id == user.hub_id => email,
+        Ok(_) => return HttpResponse::NotFound().finish(),
+        Err(err) => {
+            log::error!("Failed to get email: {err}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    let mut writer = csv::Writer::from_writer(vec![]);
+    for recipient in email.recipients {
+        if let Err(err) = writer.serialize(recipient) {
+            log::error!("Failed to write recipient to csv: {err}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    }
+
+    let data = match writer.into_inner() {
+        Ok(data) => data,
+        Err(err) => {
+            log::error!("Failed to finalize csv: {err}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/csv")
+        .append_header((
+            "Content-Disposition",
+            format!("attachment; filename=\"recipients_{email_id}.csv\""),
+        ))
+        .body(data)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,6 +36,7 @@ pub fn send_zmq_email_id(id: i32, zmq_config: &ServerConfig) -> Result<(), Box<d
 /// - `data` contains the file bytes.
 ///
 /// Any I/O error while reading the file is propagated to the caller.
+#[allow(clippy::type_complexity)]
 pub fn read_attachment_file(
     attachment: &mut TempFile,
 ) -> std::io::Result<(Option<String>, Option<String>, Option<Vec<u8>>)> {

--- a/templates/main/email.html
+++ b/templates/main/email.html
@@ -36,6 +36,11 @@
                         </button>
                     </form>
                 </div>
+                <div class="col-auto">
+                    <a href="/emails/{{email.id}}/recipients/export" class="btn btn-info btn-sm">
+                        <i class="bi bi-download"></i>
+                    </a>
+                </div>
             </div>
             <div class="row">
                 <div class="col">


### PR DESCRIPTION
## Summary
- add `/emails/{email_id}/recipients/export` route to download email recipients as CSV
- register new route in Actix server configuration

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a5641c5930832aaf929781c030beb9