### PR TITLE
feat: normalize recipient email creation

### DIFF
--- a/src/domain/recipient.rs
+++ b/src/domain/recipient.rs
@@ -52,6 +52,33 @@ pub struct NewRecipient {
     pub groups: Option<Vec<String>>,
 }
 
+impl NewRecipient {
+    /// Creates a new [`NewRecipient`] ensuring that the email is stored in lowercase.
+    ///
+    /// # Parameters
+    /// - `name`: Name of the recipient.
+    /// - `email`: Email address which will be normalized to lowercase.
+    /// - `hub_id`: Hub to associate with the recipient.
+    /// - `fields`: Optional set of custom fields.
+    /// - `groups`: Optional list of group names to subscribe the recipient to.
+    #[must_use]
+    pub fn new(
+        name: String,
+        email: String,
+        hub_id: i32,
+        fields: Option<HashMap<String, String>>,
+        groups: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            name,
+            email: email.to_lowercase(),
+            hub_id,
+            fields,
+            groups,
+        }
+    }
+}
+
 /// Fields that can be modified for an existing [`Recipient`].
 pub struct UpdateRecipient {
     /// Updated name.

--- a/src/forms/recipients.rs
+++ b/src/forms/recipients.rs
@@ -131,7 +131,7 @@ impl UploadRecipientsForm {
             for (i, field) in record.iter().enumerate() {
                 match headers.get(i) {
                     Some("name") => name = field.trim().to_string(),
-                    Some("email") => email = field.trim().to_lowercase(),
+                    Some("email") => email = field.trim().to_string(),
                     Some("groups") => {
                         groups = field
                             .split(',')
@@ -154,13 +154,13 @@ impl UploadRecipientsForm {
                 continue;
             }
 
-            recipients.push(NewRecipient {
+            recipients.push(NewRecipient::new(
                 name,
                 email,
                 hub_id,
-                groups: Some(groups),
-                fields: Some(optional_fields),
-            });
+                Some(optional_fields),
+                Some(groups),
+            ));
         }
 
         Ok(recipients)
@@ -169,13 +169,7 @@ impl UploadRecipientsForm {
 
 impl From<AddRecipientForm> for NewRecipient {
     fn from(form: AddRecipientForm) -> Self {
-        Self {
-            name: form.name,
-            email: form.email,
-            hub_id: 0,
-            groups: None,
-            fields: None,
-        }
+        NewRecipient::new(form.name, form.email, 0, None, None)
     }
 }
 

--- a/src/repository/recipient.rs
+++ b/src/repository/recipient.rs
@@ -176,10 +176,9 @@ impl RecipientWriter for DieselRepository {
             let mut count_inserted: usize = 0;
 
             for new in recipient {
-                let email = new.email.to_lowercase();
                 let db_new = NewRecipient {
                     name: &new.name,
-                    email: email.as_str(),
+                    email: &new.email,
                     hub_id: new.hub_id,
                 };
 


### PR DESCRIPTION
## Summary
- add constructor for `NewRecipient` that lowercases email on creation
- remove scattered manual email lowercasing

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose`
- `cargo test --verbose` *(fails: timed out or not run to completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b3291a0304832ab9ccc60b42b5a28f