### PR TITLE
feat: normalize recipient email creation

### DIFF
--- a/src/domain/group.rs
+++ b/src/domain/group.rs
@@ -28,9 +28,9 @@ pub struct GroupWithRecipients {
 }
 
 /// Parameters to create a new [`Group`].
-pub struct NewGroup<'a> {
+pub struct NewGroup {
     /// Name of the group.
-    pub name: &'a str,
+    pub name: String,
     /// Hub that will own the group.
     pub hub_id: i32,
 }

--- a/src/domain/hub.rs
+++ b/src/domain/hub.rs
@@ -29,17 +29,17 @@ pub struct Hub {
 }
 
 /// Data required to create a new [`Hub`].
-pub struct NewHub<'a> {
+pub struct NewHub {
     /// Identifier of the hub to be created.
     pub id: i32,
     /// Login used for SMTP authentication.
-    pub login: Option<&'a str>,
+    pub login: Option<String>,
     /// Password for the SMTP login.
-    pub password: Option<&'a str>,
+    pub password: Option<String>,
     /// Sender address used in outgoing emails.
-    pub sender: Option<&'a str>,
+    pub sender: Option<String>,
     /// SMTP server hostname.
-    pub smtp_server: Option<&'a str>,
+    pub smtp_server: Option<String>,
     /// SMTP server port.
     pub smtp_port: Option<i32>,
     /// Creation timestamp.
@@ -47,23 +47,23 @@ pub struct NewHub<'a> {
     /// Last update timestamp.
     pub updated_at: Option<NaiveDateTime>,
     /// IMAP server hostname.
-    pub imap_server: Option<&'a str>,
+    pub imap_server: Option<String>,
     /// IMAP server port.
     pub imap_port: Option<i32>,
     /// Template applied to outgoing emails.
-    pub email_template: Option<&'a str>,
+    pub email_template: Option<String>,
 }
 
 /// Fields that can be updated for an existing [`Hub`].
-pub struct UpdateHub<'a> {
+pub struct UpdateHub {
     /// New login for SMTP authentication.
-    pub login: Option<&'a str>,
+    pub login: Option<String>,
     /// New password for the login.
-    pub password: Option<&'a str>,
+    pub password: Option<String>,
     /// Updated sender address.
-    pub sender: Option<&'a str>,
+    pub sender: Option<String>,
     /// Updated SMTP server hostname.
-    pub smtp_server: Option<&'a str>,
+    pub smtp_server: Option<String>,
     /// Updated SMTP port.
     pub smtp_port: Option<i32>,
     /// Updated creation timestamp.
@@ -71,11 +71,11 @@ pub struct UpdateHub<'a> {
     /// Updated modification timestamp.
     pub updated_at: Option<NaiveDateTime>,
     /// Updated IMAP server hostname.
-    pub imap_server: Option<&'a str>,
+    pub imap_server: Option<String>,
     /// Updated IMAP port.
     pub imap_port: Option<i32>,
     /// Updated email template.
-    pub email_template: Option<&'a str>,
+    pub email_template: Option<String>,
 }
 
 impl Hub {
@@ -92,7 +92,7 @@ impl Hub {
     }
 }
 
-impl<'a> NewHub<'a> {
+impl NewHub {
     pub fn new(id: i32) -> Self {
         Self {
             id,

--- a/src/domain/recipient.rs
+++ b/src/domain/recipient.rs
@@ -52,6 +52,33 @@ pub struct NewRecipient {
     pub groups: Option<Vec<String>>,
 }
 
+impl NewRecipient {
+    /// Creates a new [`NewRecipient`] ensuring that the email is stored in lowercase.
+    ///
+    /// # Parameters
+    /// - `name`: Name of the recipient.
+    /// - `email`: Email address which will be normalized to lowercase.
+    /// - `hub_id`: Hub to associate with the recipient.
+    /// - `fields`: Optional set of custom fields.
+    /// - `groups`: Optional list of group names to subscribe the recipient to.
+    #[must_use]
+    pub fn new(
+        name: String,
+        email: String,
+        hub_id: i32,
+        fields: Option<HashMap<String, String>>,
+        groups: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            name,
+            email: email.to_lowercase(),
+            hub_id,
+            fields,
+            groups,
+        }
+    }
+}
+
 /// Fields that can be modified for an existing [`Recipient`].
 pub struct UpdateRecipient {
     /// Updated name.

--- a/src/forms/groups.rs
+++ b/src/forms/groups.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 use validator::Validate;
 
+use crate::domain::group::NewGroup;
+
 /// Form data for creating a new recipient group.
 #[derive(Deserialize, Validate)]
 pub struct AddGroupForm {
@@ -19,4 +21,13 @@ pub struct DeleteGroupForm {
 pub struct AssignGroupRecipientForm {
     pub recipient_id: i32,
     pub group_id: i32,
+}
+
+impl AddGroupForm {
+    pub fn to_new_group(&self, hub_id: i32) -> NewGroup {
+        NewGroup {
+            name: self.name.clone(),
+            hub_id,
+        }
+    }
 }

--- a/src/forms/recipients.rs
+++ b/src/forms/recipients.rs
@@ -131,7 +131,7 @@ impl UploadRecipientsForm {
             for (i, field) in record.iter().enumerate() {
                 match headers.get(i) {
                     Some("name") => name = field.trim().to_string(),
-                    Some("email") => email = field.trim().to_lowercase(),
+                    Some("email") => email = field.trim().to_string(),
                     Some("groups") => {
                         groups = field
                             .split(',')
@@ -154,13 +154,13 @@ impl UploadRecipientsForm {
                 continue;
             }
 
-            recipients.push(NewRecipient {
+            recipients.push(NewRecipient::new(
                 name,
                 email,
                 hub_id,
-                groups: Some(groups),
-                fields: Some(optional_fields),
-            });
+                Some(optional_fields),
+                Some(groups),
+            ));
         }
 
         Ok(recipients)
@@ -169,13 +169,7 @@ impl UploadRecipientsForm {
 
 impl From<AddRecipientForm> for NewRecipient {
     fn from(form: AddRecipientForm) -> Self {
-        Self {
-            name: form.name,
-            email: form.email,
-            hub_id: 0,
-            groups: None,
-            fields: None,
-        }
+        NewRecipient::new(form.name, form.email, 0, None, None)
     }
 }
 

--- a/src/forms/settings.rs
+++ b/src/forms/settings.rs
@@ -23,19 +23,19 @@ pub struct SaveHubForm {
     pub message: Option<String>,
 }
 
-impl<'a> From<&'a SaveHubForm> for UpdateHub<'a> {
-    fn from(val: &'a SaveHubForm) -> Self {
+impl From<SaveHubForm> for UpdateHub {
+    fn from(val: SaveHubForm) -> Self {
         Self {
-            login: val.login.as_deref(),
-            password: val.password.as_deref(),
-            sender: val.sender.as_deref(),
-            smtp_server: val.smtp_server.as_deref(),
+            login: val.login,
+            password: val.password,
+            sender: val.sender,
+            smtp_server: val.smtp_server,
             smtp_port: val.smtp_port,
-            imap_server: val.imap_server.as_deref(),
+            imap_server: val.imap_server,
             imap_port: val.imap_port,
             created_at: val.created_at,
             updated_at: Some(chrono::Utc::now().naive_utc()),
-            email_template: val.message.as_deref(),
+            email_template: val.message,
         }
     }
 }

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -1,5 +1,6 @@
 use diesel::prelude::*;
 
+use crate::domain::group::{Group as DomainGroup, NewGroup as DomainNewGroup};
 use crate::models::hub::Hub;
 use crate::models::recipient::Recipient;
 
@@ -32,9 +33,7 @@ pub struct GroupRecipient {
     pub recipient_id: i32,
 }
 
-use crate::domain::group as domain;
-
-impl From<Group> for domain::Group {
+impl From<Group> for DomainGroup {
     fn from(value: Group) -> Self {
         Self {
             id: value.id,
@@ -42,6 +41,15 @@ impl From<Group> for domain::Group {
             hub_id: value.hub_id,
             created_at: value.created_at,
             updated_at: value.updated_at,
+        }
+    }
+}
+
+impl<'a> From<&'a DomainNewGroup> for NewGroup<'a> {
+    fn from(value: &'a DomainNewGroup) -> Self {
+        Self {
+            name: value.name.as_str(),
+            hub_id: value.hub_id,
         }
     }
 }

--- a/src/models/hub.rs
+++ b/src/models/hub.rs
@@ -69,37 +69,37 @@ impl From<Hub> for DomainHub {
     }
 }
 
-impl<'a> From<&DomainNewHub<'a>> for NewHub<'a> {
-    fn from(value: &DomainNewHub<'a>) -> Self {
+impl<'a> From<&'a DomainNewHub> for NewHub<'a> {
+    fn from(value: &'a DomainNewHub) -> Self {
         Self {
             id: value.id,
-            login: value.login,
-            password: value.password,
-            sender: value.sender,
-            smtp_server: value.smtp_server,
+            login: value.login.as_deref(),
+            password: value.password.as_deref(),
+            sender: value.sender.as_deref(),
+            smtp_server: value.smtp_server.as_deref(),
             smtp_port: value.smtp_port,
             created_at: value.created_at,
             updated_at: value.updated_at,
-            imap_server: value.imap_server,
+            imap_server: value.imap_server.as_deref(),
             imap_port: value.imap_port,
-            email_template: value.email_template,
+            email_template: value.email_template.as_deref(),
         }
     }
 }
 
-impl<'a> From<&DomainUpdateHub<'a>> for UpdateHub<'a> {
-    fn from(value: &DomainUpdateHub<'a>) -> Self {
+impl<'a> From<&'a DomainUpdateHub> for UpdateHub<'a> {
+    fn from(value: &'a DomainUpdateHub) -> Self {
         Self {
-            login: value.login,
-            password: value.password,
-            sender: value.sender,
-            smtp_server: value.smtp_server,
+            login: value.login.as_deref(),
+            password: value.password.as_deref(),
+            sender: value.sender.as_deref(),
+            smtp_server: value.smtp_server.as_deref(),
             smtp_port: value.smtp_port,
             created_at: value.created_at,
             updated_at: value.updated_at,
-            imap_server: value.imap_server,
+            imap_server: value.imap_server.as_deref(),
             imap_port: value.imap_port,
-            email_template: value.email_template,
+            email_template: value.email_template.as_deref(),
         }
     }
 }

--- a/src/models/recipient.rs
+++ b/src/models/recipient.rs
@@ -1,6 +1,7 @@
 use diesel::prelude::*;
 use serde::Serialize;
 
+use crate::domain::recipient::NewRecipient as DomainNewRecipient;
 use crate::models::hub::Hub;
 
 #[derive(Queryable, Selectable, Serialize, Identifiable, Associations, QueryableByName)]
@@ -33,4 +34,14 @@ pub struct RecipientField {
     pub recipient_id: i32,
     pub field: String,
     pub value: String,
+}
+
+impl<'a> From<&'a DomainNewRecipient> for NewRecipient<'a> {
+    fn from(value: &'a DomainNewRecipient) -> Self {
+        Self {
+            name: &value.name,
+            email: &value.email,
+            hub_id: value.hub_id,
+        }
+    }
 }

--- a/src/repository/group.rs
+++ b/src/repository/group.rs
@@ -128,10 +128,7 @@ impl GroupWriter for DieselRepository {
     fn create_group(&self, group: &DomainNewGroup) -> RepositoryResult<DomainGroup> {
         use crate::schema::groups;
         let mut conn = self.conn()?;
-        let db_new = DbNewGroup {
-            name: group.name,
-            hub_id: group.hub_id,
-        };
+        let db_new: DbNewGroup = group.into();
         let inserted = diesel::insert_into(groups::table)
             .values(&db_new)
             .get_result::<DbGroup>(&mut conn)?;

--- a/src/repository/recipient.rs
+++ b/src/repository/recipient.rs
@@ -176,11 +176,7 @@ impl RecipientWriter for DieselRepository {
             let mut count_inserted: usize = 0;
 
             for new in recipient {
-                let db_new = NewRecipient {
-                    name: &new.name,
-                    email: &new.email,
-                    hub_id: new.hub_id,
-                };
+                let db_new: NewRecipient = new.into();
 
                 let inserted = diesel::insert_into(recipients::table)
                     .values(&db_new)

--- a/src/repository/recipient.rs
+++ b/src/repository/recipient.rs
@@ -176,10 +176,9 @@ impl RecipientWriter for DieselRepository {
             let mut count_inserted: usize = 0;
 
             for new in recipient {
-                let email = new.email.to_lowercase();
                 let db_new = NewRecipient {
                     name: &new.name,
-                    email: email.as_str(),
+                    email: &new.email,
                     hub_id: new.hub_id,
                 };
 

--- a/src/routes/groups.rs
+++ b/src/routes/groups.rs
@@ -7,7 +7,6 @@ use pushkind_common::routes::{ensure_role, redirect};
 use tera::{Context, Tera};
 use validator::Validate;
 
-use crate::domain::group::NewGroup;
 use crate::forms::groups::{AddGroupForm, AssignGroupRecipientForm, DeleteGroupForm};
 use crate::repository::{
     DieselRepository, GroupListQuery, GroupReader, GroupWriter, RecipientListQuery, RecipientReader,
@@ -80,10 +79,7 @@ pub async fn groups_add(
         return redirect("/groups");
     }
 
-    let new_group = NewGroup {
-        hub_id: user.hub_id,
-        name: &form.name,
-    };
+    let new_group = form.to_new_group(user.hub_id);
 
     match repo.create_group(&new_group) {
         Ok(_) => {

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -74,7 +74,7 @@ pub async fn settings_save(
         }
     };
 
-    match repo.update_hub(hub.id, &(&form).into()) {
+    match repo.update_hub(hub.id, &form.into()) {
         Ok(_) => {
             FlashMessage::success("Хаб сохранён.").send();
         }


### PR DESCRIPTION
## Summary
- add constructor for `NewRecipient` that lowercases email on creation
- remove scattered manual email lowercasing

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose`
- `cargo test --verbose` *(fails: timed out or not run to completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b3291a0304832ab9ccc60b42b5a28f