### PR TITLE
feat: normalize recipient email creation

### DIFF
--- a/src/forms/recipients.rs
+++ b/src/forms/recipients.rs
@@ -204,7 +204,20 @@ impl SourceRecipientForm {
             .await?;
 
         if response.status().is_success() {
-            let recipients: Vec<NewRecipient> = response.json().await?;
+            #[derive(Deserialize)]
+            struct SourceRecipient {
+                name: String,
+                email: String,
+                hub_id: i32,
+                fields: Option<HashMap<String, String>>,
+                groups: Option<Vec<String>>,
+            }
+
+            let recipients: Vec<SourceRecipient> = response.json().await?;
+            let recipients = recipients
+                .into_iter()
+                .map(|r| NewRecipient::new(r.name, r.email, r.hub_id, r.fields, r.groups))
+                .collect();
             Ok(recipients)
         } else {
             Err(SourceRecipientFormError::RequestError)


### PR DESCRIPTION
## Summary
- ensure JSON-loaded recipients are lowercased when converted to domain objects
- remove repository-level email normalization

## Testing
- `cargo fmt -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b3d0479c8c832ab5d4b500df19d532