### PR TITLE
feat: poll hubs for replies continuously

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -44,11 +44,16 @@ jobs:
           if_key_exists: fail # replace / ignore / fail; optional (defaults to fail)
       - name: Deploy
         run: |
-          ssh cicd@mail.pushkind.com "supervisorctl stop emailer_dev && supervisorctl stop emailer_sender_dev"
+          ssh cicd@mail.pushkind.com "supervisorctl stop emailer"
+          ssh cicd@mail.pushkind.com "supervisorctl stop emailer_send_email"
+          ssh cicd@mail.pushkind.com "supervisorctl stop emailer_check_reply"
           scp ./target/release/pushkind-emailer cicd@mail.pushkind.com:/var/www5/html/
           scp ./target/release/send_email cicd@mail.pushkind.com:/var/www5/html/
           scp ./target/release/check_reply cicd@mail.pushkind.com:/var/www5/html/
           scp -r ./assets/ cicd@mail.pushkind.com:/var/www5/html/
           scp -r ./templates/ cicd@mail.pushkind.com:/var/www5/html/
           scp -r ./migrations/ cicd@mail.pushkind.com:/var/www5/html/
-          ssh cicd@mail.pushkind.com "cd /var/www5/html/ && /home/cicd/.cargo/bin/diesel migration run && supervisorctl start emailer_dev && supervisorctl start emailer_sender_dev"
+          ssh cicd@mail.pushkind.com "cd /var/www5/html/ && /home/cicd/.cargo/bin/diesel migration run"
+          ssh cicd@mail.pushkind.com "supervisorctl start emailer"
+          ssh cicd@mail.pushkind.com "supervisorctl start emailer_send_email"
+          ssh cicd@mail.pushkind.com "supervisorctl start emailer_check_reply"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ the Pushkind ecosystem. Built with Rust, Actix Web and Diesel, it handles
 creation of arbitrary email recipients as well as loading them from
 pushkind-auth and pushkind-crm, and creating email messages.
 Additional binaries `send_email` and `check_reply` handle sending emails over SMTP
-and checking for replies over IMAP. The `check_reply` binary runs continuously,
-periodically polling hubs for new replies.
+and checking for replies over IMAP. The `check_reply` binary establishes a
+persistent connection to each hub and updates recipients as new replies arrive.
 
 ## Features
 
@@ -25,7 +25,7 @@ by pushkind-auth
    - `AUTH_SERVICE_URL` for redirects to the auth service
    - `CRM_SERVICE_URL` for the crm service to load client emails from
    - `ZMQ_ADDRESS` for the send_email binary to send emails to
-   - Optional: `PORT`, `ADDRESS`, `DOMAIN`, `CHECK_REPLY_INTERVAL_SECS` (interval in seconds for the check_reply service; defaults to 60)
+   - Optional: `PORT`, `ADDRESS`, `DOMAIN`
 3. Run database migrations with `diesel migration run` (requires `diesel-cli`).
 4. Start the server:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 the Pushkind ecosystem. Built with Rust, Actix Web and Diesel, it handles
 creation of arbitrary email recipients as well as loading them from
 pushkind-auth and pushkind-crm, and creating email messages.
-Additional binaries send_email and check_reply handle sending emails over SMTP
-and checking if there's been a reply over IMAP.
+Additional binaries `send_email` and `check_reply` handle sending emails over SMTP
+and checking for replies over IMAP. The `check_reply` binary runs continuously,
+periodically polling hubs for new replies.
 
 ## Features
 
@@ -24,7 +25,7 @@ by pushkind-auth
    - `AUTH_SERVICE_URL` for redirects to the auth service
    - `CRM_SERVICE_URL` for the crm service to load client emails from
    - `ZMQ_ADDRESS` for the send_email binary to send emails to
-   - Optional: `PORT`, `ADDRESS`, `DOMAIN`
+   - Optional: `PORT`, `ADDRESS`, `DOMAIN`, `CHECK_REPLY_INTERVAL_SECS` (interval in seconds for the check_reply service; defaults to 60)
 3. Run database migrations with `diesel migration run` (requires `diesel-cli`).
 4. Start the server:
 

--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -80,7 +80,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
                 (server, port as u16, username, password)
             }
             _ => {
-                log::error!("Cannot get imap server and port for the hub");
+                log::error!("Cannot get imap server and port for the hub#{}", hub.id);
                 return;
             }
         };
@@ -88,14 +88,14 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
     let tls = match native_tls::TlsConnector::builder().build() {
         Ok(tls) => tls,
         Err(e) => {
-            log::error!("Cannot build tls connector: {e}");
+            log::error!("Cannot build tls connector for hub#{}: {e}", hub.id);
             return;
         }
     };
     let client = match imap::connect((imap_server.as_str(), imap_port), imap_server, &tls) {
         Ok(client) => client,
         Err(e) => {
-            log::error!("Cannot connect to imap server: {e}");
+            log::error!("Cannot connect to imap server in hub#{}: {e}", hub.id);
             return;
         }
     };
@@ -103,31 +103,36 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
     let mut session = match client.login(username, password).map_err(|e| e.0) {
         Ok(session) => session,
         Err(e) => {
-            log::error!("Cannot login to imap server: {e}");
+            log::error!("Cannot login to imap server in hub#{}: {e}", hub.id);
             return;
         }
     };
 
     if let Err(e) = session.select("INBOX") {
-        log::error!("Cannot select INBOX: {e}");
+        log::error!("Cannot select INBOX in hub#{}: {e}", hub.id);
         return;
     }
 
     let recipients = match repo.list_not_replied_email_recipients(hub.id) {
         Ok(r) => r,
         Err(e) => {
-            log::error!("Cannot get recipients: {e}");
+            log::error!("Cannot get recipients in hub#{}: {e}", hub.id);
             Vec::new()
         }
     };
 
+    log::info!(
+        "Found {} recipients for the startup check in hub#{}",
+        recipients.len(),
+        hub.id,
+    );
     for recipient in recipients {
         let in_reply_to_id = format!("<{}@{}>", recipient.id, domain);
         let query = format!("HEADER In-Reply-To {in_reply_to_id}");
         let search_result = match session.search(&query) {
             Ok(res) => res,
             Err(e) => {
-                log::error!("Cannot search for emails: {e}");
+                log::error!("Cannot search for emails in hub#{}: {e}", hub.id);
                 continue;
             }
         };
@@ -143,7 +148,11 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
             ) {
                 log::error!("Cannot set email recipient replied status: {e}");
             } else {
-                log::info!("Email recipient replied status set");
+                log::info!(
+                    "Email recipient replied status set for {}, email id: {}",
+                    &recipient.address,
+                    recipient.email_id
+                );
             }
         }
     }
@@ -154,9 +163,10 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
         .and_then(|uids| uids.into_iter().max())
         .unwrap_or(0);
 
+    log::info!("Starting a monitoring loop for hub#{}", hub.id);
     loop {
         if let Err(e) = session.idle().and_then(|idle| idle.wait_keepalive()) {
-            log::error!("Idle error: {e}");
+            log::error!("Idle error in hub#{}: {e}", hub.id);
             break;
         }
 
@@ -164,7 +174,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
         let new_uids = match session.uid_search(&search_query) {
             Ok(uids) => uids,
             Err(e) => {
-                log::error!("Cannot search new emails: {e}");
+                log::error!("Cannot search new emails in hub#{}: {e}", hub.id);
                 continue;
             }
         };
@@ -179,7 +189,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
     }
 
     if let Err(e) = session.logout() {
-        log::error!("Cannot logout: {e}");
+        log::error!("Cannot logout from hub#{}: {e}", hub.id);
     }
 }
 
@@ -209,13 +219,19 @@ async fn main() {
         }
     };
 
+    let mut handles = vec![];
     for hub in hubs {
         let repo = repo.clone();
         let domain = Arc::clone(&domain);
-        task::spawn_blocking(move || monitor_hub(repo, hub, domain.to_string()));
+        handles.push(task::spawn_blocking(move || {
+            monitor_hub(repo, hub, domain.to_string())
+        }));
     }
 
-    if let Err(e) = tokio::signal::ctrl_c().await {
-        log::error!("Failed to listen for ctrl_c: {e}");
+    for handle in handles {
+        match handle.await {
+            Ok(_) => (), // task finished fine
+            Err(e) => log::error!("Task panicked: {e:?}"),
+        }
     }
 }

--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::str;
 use std::sync::Arc;
 
 use dotenvy::dotenv;
@@ -7,32 +8,82 @@ use pushkind_common::domain::email::UpdateEmailRecipient;
 
 use pushkind_emailer::domain::hub::Hub;
 use pushkind_emailer::repository::{DieselRepository, EmailReader, EmailWriter, HubReader};
-use tokio::{
-    task,
-    time::{Duration, sleep},
-};
+use tokio::task;
 
-pub fn check_hub_email_replied(repo: DieselRepository, hub: &Hub, domain: &str) {
-    let recipients = match repo.list_not_replied_email_recipients(hub.id) {
-        Ok(recipients) => recipients,
+fn extract_recipient_id(header: &str, domain: &str) -> Option<i32> {
+    header
+        .lines()
+        .find(|line| line.starts_with("In-Reply-To:"))
+        .and_then(|line| line.split('<').nth(1))
+        .and_then(|part| part.split('>').next())
+        .and_then(|msg_id| {
+            let mut parts = msg_id.split('@');
+            match (parts.next(), parts.next()) {
+                (Some(id), Some(d)) if d == domain => id.parse().ok(),
+                _ => None,
+            }
+        })
+}
+
+fn process_new_message(
+    repo: &DieselRepository,
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    uid: u32,
+    domain: &str,
+) {
+    let fetches = match session.uid_fetch(uid.to_string(), "RFC822.HEADER") {
+        Ok(f) => f,
         Err(e) => {
-            log::error!("Cannot get recipients: {e}");
+            log::error!("Cannot fetch header for UID {uid}: {e}");
             return;
         }
     };
 
+    let fetch = match fetches.iter().next() {
+        Some(f) => f,
+        None => return,
+    };
+
+    let header = match fetch.header() {
+        Some(h) => h,
+        None => return,
+    };
+
+    let header_str = match str::from_utf8(header) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Cannot parse header utf8: {e}");
+            return;
+        }
+    };
+
+    if let Some(recipient_id) = extract_recipient_id(header_str, domain) {
+        if let Err(e) = repo.update_recipient(
+            recipient_id,
+            &UpdateEmailRecipient {
+                is_sent: Some(true),
+                replied: Some(true),
+                opened: Some(true),
+            },
+        ) {
+            log::error!("Cannot set email recipient replied status: {e}");
+        } else {
+            log::info!("Email recipient replied status set for {recipient_id}");
+        }
+    }
+}
+
+fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
     let (imap_server, imap_port, username, password) =
         match (&hub.imap_server, hub.imap_port, &hub.login, &hub.password) {
             (Some(server), Some(port), Some(username), Some(password)) => {
-                (server, port, username, password)
+                (server, port as u16, username, password)
             }
             _ => {
                 log::error!("Cannot get imap server and port for the hub");
                 return;
             }
         };
-
-    let imap_port = imap_port as u16;
 
     let tls = match native_tls::TlsConnector::builder().build() {
         Ok(tls) => tls,
@@ -49,7 +100,7 @@ pub fn check_hub_email_replied(repo: DieselRepository, hub: &Hub, domain: &str) 
         }
     };
 
-    let mut session: imap::Session<_> = match client.login(username, password).map_err(|e| e.0) {
+    let mut session = match client.login(username, password).map_err(|e| e.0) {
         Ok(session) => session,
         Err(e) => {
             log::error!("Cannot login to imap server: {e}");
@@ -57,37 +108,32 @@ pub fn check_hub_email_replied(repo: DieselRepository, hub: &Hub, domain: &str) 
         }
     };
 
-    match session.select("INBOX") {
-        Ok(_) => log::info!("Selected INBOX"),
-        Err(e) => {
-            log::error!("Cannot select INBOX: {e}");
-            return;
-        }
+    if let Err(e) = session.select("INBOX") {
+        log::error!("Cannot select INBOX: {e}");
+        return;
     }
 
-    for recipient in recipients {
-        // Define the In-Reply-To Message-ID you are looking for
-        let in_reply_to_id = format!("<{}@{}>", recipient.id, domain);
+    let recipients = match repo.list_not_replied_email_recipients(hub.id) {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("Cannot get recipients: {e}");
+            Vec::new()
+        }
+    };
 
-        // Search for emails with a matching In-Reply-To header
+    for recipient in recipients {
+        let in_reply_to_id = format!("<{}@{}>", recipient.id, domain);
         let query = format!("HEADER In-Reply-To {in_reply_to_id}");
         let search_result = match session.search(&query) {
-            Ok(search_result) => search_result,
+            Ok(res) => res,
             Err(e) => {
                 log::error!("Cannot search for emails: {e}");
                 continue;
             }
         };
 
-        if search_result.is_empty() {
-            log::info!(
-                "No matching emails found for email_id: {}, recipient: {}.",
-                recipient.email_id,
-                recipient.address
-            );
-        } else {
-            log::info!("Found emails with In-Reply-To {in_reply_to_id}: {search_result:?}");
-            match repo.update_recipient(
+        if !search_result.is_empty() {
+            if let Err(e) = repo.update_recipient(
                 recipient.id,
                 &UpdateEmailRecipient {
                     is_sent: Some(true),
@@ -95,22 +141,52 @@ pub fn check_hub_email_replied(repo: DieselRepository, hub: &Hub, domain: &str) 
                     opened: Some(true),
                 },
             ) {
-                Ok(_) => log::info!("Email recipient replied status set"),
-                Err(e) => log::error!("Cannot set email recipient replied status: {e}"),
+                log::error!("Cannot set email recipient replied status: {e}");
+            } else {
+                log::info!("Email recipient replied status set");
             }
         }
     }
 
-    match session.logout() {
-        Ok(_) => log::info!("Logged out"),
-        Err(e) => log::error!("Cannot logout: {e}"),
+    let mut last_uid = session
+        .uid_search("ALL")
+        .ok()
+        .and_then(|uids| uids.into_iter().max())
+        .unwrap_or(0);
+
+    loop {
+        if let Err(e) = session.idle().and_then(|idle| idle.wait_keepalive()) {
+            log::error!("Idle error: {e}");
+            break;
+        }
+
+        let search_query = format!("UID {}:*", last_uid + 1);
+        let new_uids = match session.uid_search(&search_query) {
+            Ok(uids) => uids,
+            Err(e) => {
+                log::error!("Cannot search new emails: {e}");
+                continue;
+            }
+        };
+
+        for uid in &new_uids {
+            process_new_message(&repo, &mut session, *uid, &domain);
+        }
+
+        if let Some(max_uid) = new_uids.iter().max() {
+            last_uid = *max_uid;
+        }
+    }
+
+    if let Err(e) = session.logout() {
+        log::error!("Cannot logout: {e}");
     }
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
-    dotenv().ok(); // Load .env file
+    dotenv().ok();
 
     let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| "app.db".to_string());
     let domain = Arc::new(env::var("DOMAIN").unwrap_or_default());
@@ -125,37 +201,21 @@ async fn main() {
 
     let repo = DieselRepository::new(db_pool);
 
-    let interval_secs = env::var("CHECK_REPLY_INTERVAL_SECS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(60);
-
-    loop {
-        let hubs = match repo.list_hubs() {
-            Ok(hub) => hub,
-            Err(e) => {
-                log::error!("Cannot get hubs: {e}");
-                sleep(Duration::from_secs(interval_secs)).await;
-                continue;
-            }
-        };
-
-        let mut handles = Vec::new();
-        for hub in hubs {
-            let repo = repo.clone();
-            let domain = Arc::clone(&domain);
-            handles.push(task::spawn_blocking(move || {
-                log::info!("Checking hub: {}", hub.id);
-                check_hub_email_replied(repo, &hub, domain.as_str());
-            }));
+    let hubs = match repo.list_hubs() {
+        Ok(h) => h,
+        Err(e) => {
+            log::error!("Cannot get hubs: {e}");
+            return;
         }
+    };
 
-        for handle in handles {
-            if let Err(e) = handle.await {
-                log::error!("Failed to join hub check task: {e}");
-            }
-        }
+    for hub in hubs {
+        let repo = repo.clone();
+        let domain = Arc::clone(&domain);
+        task::spawn_blocking(move || monitor_hub(repo, hub, domain.to_string()));
+    }
 
-        sleep(Duration::from_secs(interval_secs)).await;
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        log::error!("Failed to listen for ctrl_c: {e}");
     }
 }

--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::sync::Arc;
 
 use dotenvy::dotenv;
 use pushkind_common::db::establish_connection_pool;
@@ -6,6 +7,10 @@ use pushkind_common::domain::email::UpdateEmailRecipient;
 
 use pushkind_emailer::domain::hub::Hub;
 use pushkind_emailer::repository::{DieselRepository, EmailReader, EmailWriter, HubReader};
+use tokio::{
+    task,
+    time::{Duration, sleep},
+};
 
 pub fn check_hub_email_replied(repo: DieselRepository, hub: &Hub, domain: &str) {
     let recipients = match repo.list_not_replied_email_recipients(hub.id) {
@@ -102,12 +107,13 @@ pub fn check_hub_email_replied(repo: DieselRepository, hub: &Hub, domain: &str) 
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
     dotenv().ok(); // Load .env file
 
     let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| "app.db".to_string());
-    let domain = env::var("DOMAIN").unwrap_or_default();
+    let domain = Arc::new(env::var("DOMAIN").unwrap_or_default());
 
     let db_pool = match establish_connection_pool(&database_url) {
         Ok(pool) => pool,
@@ -119,16 +125,37 @@ fn main() {
 
     let repo = DieselRepository::new(db_pool);
 
-    let hubs = match repo.list_hubs() {
-        Ok(hub) => hub,
-        Err(e) => {
-            log::error!("Cannot get hubs: {e}");
-            return;
-        }
-    };
+    let interval_secs = env::var("CHECK_REPLY_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(60);
 
-    for hub in hubs {
-        log::info!("Checking hub: {}", hub.id);
-        check_hub_email_replied(repo.clone(), &hub, &domain);
+    loop {
+        let hubs = match repo.list_hubs() {
+            Ok(hub) => hub,
+            Err(e) => {
+                log::error!("Cannot get hubs: {e}");
+                sleep(Duration::from_secs(interval_secs)).await;
+                continue;
+            }
+        };
+
+        let mut handles = Vec::new();
+        for hub in hubs {
+            let repo = repo.clone();
+            let domain = Arc::clone(&domain);
+            handles.push(task::spawn_blocking(move || {
+                log::info!("Checking hub: {}", hub.id);
+                check_hub_email_replied(repo, &hub, domain.as_str());
+            }));
+        }
+
+        for handle in handles {
+            if let Err(e) = handle.await {
+                log::error!("Failed to join hub check task: {e}");
+            }
+        }
+
+        sleep(Duration::from_secs(interval_secs)).await;
     }
 }


### PR DESCRIPTION
## Summary
- turn `check_reply` into a long-running service that periodically polls hubs for responses
- allow interval configuration via `CHECK_REPLY_INTERVAL_SECS`
- document the new service behavior and env var

## Testing
- `cargo fmt -- --check`
- `cargo build --bin check_reply --features send-email`
- `cargo test --verbose`
- `cargo clippy --bin check_reply --features send-email -- -Dwarnings`


------
https://chatgpt.com/codex/tasks/task_e_68b494cdf280832a9b2ed37cd4c8b538