### PR TITLE
Log reply bodies when checking for email responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,22 +8,22 @@ Use these commands to verify your changes before committing:
 
 **Build**
 ```bash
-cargo build --verbose
+cargo build --all-features --verbose
 ```
 
 **Run Tests**
 ```bash
-cargo test --verbose
+cargo test --all-features --verbose
 ```
 
 **Lint (Clippy)**
 ```bash
-cargo clippy --tests -- -Dwarnings
+cargo clippy --all-features --tests -- -Dwarnings
 ```
 
 **Format**
 ```bash
-cargo fmt -- --check
+cargo fmt --all -- --check
 ```
 
 ## Code Architecture
@@ -45,8 +45,8 @@ The codebase is organized into several layers:
 ### Key Development Rules
 
 - Use idiomatic Rust everywhere
+- Follow the Clean Code and Clean Architecture principles
 - Use `thiserror` for error definitions; avoid `anyhow::Result`
 - Define error types inside their unit of fallibility
-- Run `cargo fmt`, `cargo clippy`, and `cargo test` before all commits
 - Document all public APIs and breaking changes
 - Always run formatting and linting before create PRs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,9 +937,9 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
 ]
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "pushkind-common"
 version = "0.1.0"
-source = "git+https://github.com/pushkindt/pushkind-common.git?branch=main#baecc3185298e8b8599218a2afc88cd392fb1561"
+source = "git+https://github.com/pushkindt/pushkind-common.git?branch=main#600eb565392eaa08c2a0e39ddbf1ef7aec4dcbf8"
 dependencies = [
  "actix-identity",
  "actix-web",
@@ -3461,12 +3461,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3476,15 +3475,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
 dependencies = [
  "num-conv",
  "time-core",

--- a/migrations/2025-09-01-091000_add-email-recipient-reply-message/down.sql
+++ b/migrations/2025-09-01-091000_add-email-recipient-reply-message/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE email_recipients DROP COLUMN reply;

--- a/migrations/2025-09-01-091000_add-email-recipient-reply-message/up.sql
+++ b/migrations/2025-09-01-091000_add-email-recipient-reply-message/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE email_recipients ADD COLUMN reply TEXT;

--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use dotenvy::dotenv;
 use pushkind_common::db::establish_connection_pool;
+use pushkind_common::domain::email::EmailRecipient;
 use pushkind_common::domain::email::UpdateEmailRecipient;
+use pushkind_common::models::zmq::emailer::ZMQReplyMessage;
+use pushkind_common::zmq::{ZmqSender, ZmqSenderOptions};
 
 use pushkind_emailer::domain::hub::Hub;
 use pushkind_emailer::repository::{DieselRepository, EmailReader, EmailWriter, HubReader};
@@ -49,11 +52,45 @@ fn fetch_message_body(
     }
 }
 
+fn process_reply(
+    repo: &DieselRepository,
+    hub_id: i32,
+    recipient: &EmailRecipient,
+    reply: Option<String>,
+    zmq_sender: &ZmqSender,
+) {
+    let msg = ZMQReplyMessage {
+        hub_id,
+        email: recipient.address.clone(),
+        message: reply.clone().unwrap_or_default(),
+    };
+    if let Err(e) = tokio::runtime::Handle::current().block_on(zmq_sender.send_json(&msg)) {
+        log::error!("Cannot send ZMQ message: {e}");
+    } else {
+        log::info!("ZMQ message sent for email id: {}", recipient.email_id);
+    }
+    if let Err(e) = repo.update_recipient(
+        recipient.id,
+        &UpdateEmailRecipient {
+            is_sent: Some(true),
+            replied: Some(true),
+            opened: Some(true),
+            reply,
+        },
+    ) {
+        log::error!("Cannot set email recipient replied status: {e}");
+    } else {
+        log::info!("Email recipient replied status set for {}", recipient.id);
+    }
+}
+
 fn process_new_message(
     repo: &DieselRepository,
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
     uid: u32,
     domain: &str,
+    hub_id: i32,
+    zmq_sender: &ZmqSender,
 ) {
     let fetches = match session.uid_fetch(uid.to_string(), "RFC822.HEADER") {
         Ok(f) => f,
@@ -82,25 +119,25 @@ fn process_new_message(
     };
 
     if let Some(recipient_id) = extract_recipient_id(header_str, domain) {
-        if let Some(body) = fetch_message_body(session, uid) {
-            log::info!("Reply body for recipient {recipient_id}:\n{body}");
-        }
-        if let Err(e) = repo.update_recipient(
-            recipient_id,
-            &UpdateEmailRecipient {
-                is_sent: Some(true),
-                replied: Some(true),
-                opened: Some(true),
-            },
-        ) {
-            log::error!("Cannot set email recipient replied status: {e}");
-        } else {
-            log::info!("Email recipient replied status set for {recipient_id}");
+        let reply = fetch_message_body(session, uid);
+        match repo.get_email_recipient(recipient_id, hub_id) {
+            Ok(Some(recipient)) => process_reply(repo, hub_id, &recipient, reply, zmq_sender),
+            Ok(None) => log::warn!(
+                "Recipient not found for id {} in hub#{}",
+                recipient_id,
+                hub_id,
+            ),
+            Err(e) => log::error!(
+                "Failed to load recipient id {} in hub#{}: {}",
+                recipient_id,
+                hub_id,
+                e,
+            ),
         }
     }
 }
 
-fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
+fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String, zmq_sender: &ZmqSender) {
     let (imap_server, imap_port, username, password) =
         match (&hub.imap_server, hub.imap_port, &hub.login, &hub.password) {
             (Some(server), Some(port), Some(username), Some(password)) => {
@@ -156,7 +193,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
     for recipient in recipients {
         let in_reply_to_id = format!("<{}@{}>", recipient.id, domain);
         let query = format!("HEADER In-Reply-To {in_reply_to_id}");
-        let search_result = match session.search(&query) {
+        let search_result = match session.uid_search(&query) {
             Ok(res) => res,
             Err(e) => {
                 log::error!("Cannot search for emails in hub#{}: {e}", hub.id);
@@ -164,33 +201,9 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
             }
         };
 
-        if !search_result.is_empty() {
-            for uid in search_result.iter() {
-                if let Some(body) = fetch_message_body(&mut session, *uid) {
-                    log::info!(
-                        "Reply body for {} (email id {}):\n{}",
-                        &recipient.address,
-                        recipient.email_id,
-                        body
-                    );
-                }
-            }
-            if let Err(e) = repo.update_recipient(
-                recipient.id,
-                &UpdateEmailRecipient {
-                    is_sent: Some(true),
-                    replied: Some(true),
-                    opened: Some(true),
-                },
-            ) {
-                log::error!("Cannot set email recipient replied status: {e}");
-            } else {
-                log::info!(
-                    "Email recipient replied status set for {}, email id: {}",
-                    &recipient.address,
-                    recipient.email_id
-                );
-            }
+        if let Some(uid) = search_result.iter().max() {
+            let reply = fetch_message_body(&mut session, *uid);
+            process_reply(&repo, hub.id, &recipient, reply, zmq_sender);
         }
     }
 
@@ -217,7 +230,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
         };
 
         for uid in &new_uids {
-            process_new_message(&repo, &mut session, *uid, &domain);
+            process_new_message(&repo, &mut session, *uid, &domain, hub.id, zmq_sender);
         }
 
         if let Some(max_uid) = new_uids.iter().max() {
@@ -237,6 +250,7 @@ async fn main() {
 
     let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| "app.db".to_string());
     let domain = Arc::new(env::var("DOMAIN").unwrap_or_default());
+    let zmq_address = env::var("ZMQ_REPLIER_PUB").unwrap_or("tcp://127.0.0.1:5559".to_string());
 
     let db_pool = match establish_connection_pool(&database_url) {
         Ok(pool) => pool,
@@ -247,6 +261,10 @@ async fn main() {
     };
 
     let repo = DieselRepository::new(db_pool);
+
+    let zmq_sender = Arc::new(ZmqSender::start(ZmqSenderOptions::pub_default(
+        &zmq_address,
+    )));
 
     let hubs = match repo.list_hubs() {
         Ok(h) => h,
@@ -260,8 +278,9 @@ async fn main() {
     for hub in hubs {
         let repo = repo.clone();
         let domain = Arc::clone(&domain);
+        let zmq_sender = zmq_sender.clone();
         handles.push(task::spawn_blocking(move || {
-            monitor_hub(repo, hub, domain.to_string())
+            monitor_hub(repo, hub, domain.to_string(), &zmq_sender)
         }));
     }
 

--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -13,6 +13,87 @@ use pushkind_emailer::domain::hub::Hub;
 use pushkind_emailer::repository::{DieselRepository, EmailReader, EmailWriter, HubReader};
 use tokio::task;
 
+fn strip_html_tags(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut in_tag = false;
+    for c in input.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn extract_plain_reply(input: &str) -> String {
+    // 1) Strip HTML tags if present
+    let without_html = strip_html_tags(input);
+    // 2) Normalize newlines
+    let normalized = without_html.replace('\r', "");
+    // 3) Remove quoted lines and cut off at common quote separators
+    let mut result_lines = Vec::new();
+    for line in normalized.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            // Keep single blank lines, but avoid leading whitespace-only content
+            if !result_lines.is_empty() {
+                result_lines.push(String::new());
+            }
+            continue;
+        }
+
+        // Stop at typical reply separators
+        let lower = trimmed.to_lowercase();
+        let is_gmail_sep = lower.starts_with("on ") && lower.ends_with(" wrote:");
+        let is_original_msg = lower.contains("original message")
+            || lower.contains("пересылаемое сообщение")
+            || lower.contains("исходное сообщение");
+        let is_header_block = lower.starts_with("from:")
+            || lower.starts_with("от кого:")
+            || lower.starts_with("subject:")
+            || lower.starts_with("тема:")
+            || lower.starts_with("to:")
+            || lower.starts_with("кому:")
+            || lower.starts_with("date:")
+            || lower.starts_with("дата:");
+
+        if is_gmail_sep || is_original_msg {
+            break;
+        }
+        if is_header_block && !result_lines.is_empty() {
+            // If we already captured something, hitting a header likely indicates quoted section
+            break;
+        }
+        // Skip quoted lines that begin with '>'
+        if trimmed.starts_with('>') {
+            continue;
+        }
+        result_lines.push(trimmed.to_string());
+    }
+
+    let mut reply = result_lines.join("\n");
+    reply = reply.trim().to_string();
+
+    if reply.is_empty() {
+        // Fallback: take the first non-empty, non-quote paragraph
+        for para in normalized.split("\n\n") {
+            let p = para
+                .lines()
+                .filter(|l| !l.trim().starts_with('>'))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let p = p.trim();
+            if !p.is_empty() {
+                reply = p.to_string();
+                break;
+            }
+        }
+    }
+    reply
+}
+
 fn extract_recipient_id(header: &str, domain: &str) -> Option<i32> {
     header
         .lines()
@@ -119,7 +200,7 @@ fn process_new_message(
     };
 
     if let Some(recipient_id) = extract_recipient_id(header_str, domain) {
-        let reply = fetch_message_body(session, uid);
+        let reply = fetch_message_body(session, uid).map(|b| extract_plain_reply(&b));
         match repo.get_email_recipient(recipient_id, hub_id) {
             Ok(Some(recipient)) => process_reply(repo, hub_id, &recipient, reply, zmq_sender),
             Ok(None) => log::warn!(
@@ -202,7 +283,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String, zmq_sender: &Zm
         };
 
         if let Some(uid) = search_result.iter().max() {
-            let reply = fetch_message_body(&mut session, *uid);
+            let reply = fetch_message_body(&mut session, *uid).map(|b| extract_plain_reply(&b));
             process_reply(&repo, hub.id, &recipient, reply, zmq_sender);
         }
     }

--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -25,6 +25,30 @@ fn extract_recipient_id(header: &str, domain: &str) -> Option<i32> {
         })
 }
 
+fn fetch_message_body(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    uid: u32,
+) -> Option<String> {
+    let fetches = match session.uid_fetch(uid.to_string(), "RFC822.TEXT") {
+        Ok(f) => f,
+        Err(e) => {
+            log::error!("Cannot fetch body for UID {uid}: {e}");
+            return None;
+        }
+    };
+
+    let fetch = fetches.iter().next()?;
+    let body = fetch.text().or_else(|| fetch.body())?;
+
+    match str::from_utf8(body) {
+        Ok(s) => Some(s.to_string()),
+        Err(e) => {
+            log::error!("Cannot parse body utf8 for UID {uid}: {e}");
+            None
+        }
+    }
+}
+
 fn process_new_message(
     repo: &DieselRepository,
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
@@ -58,6 +82,9 @@ fn process_new_message(
     };
 
     if let Some(recipient_id) = extract_recipient_id(header_str, domain) {
+        if let Some(body) = fetch_message_body(session, uid) {
+            log::info!("Reply body for recipient {recipient_id}:\n{body}");
+        }
         if let Err(e) = repo.update_recipient(
             recipient_id,
             &UpdateEmailRecipient {
@@ -138,6 +165,16 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String) {
         };
 
         if !search_result.is_empty() {
+            for uid in search_result.iter() {
+                if let Some(body) = fetch_message_body(&mut session, *uid) {
+                    log::info!(
+                        "Reply body for {} (email id {}):\n{}",
+                        &recipient.address,
+                        recipient.email_id,
+                        body
+                    );
+                }
+            }
             if let Err(e) = repo.update_recipient(
                 recipient.id,
                 &UpdateEmailRecipient {

--- a/src/bin/send_email.rs
+++ b/src/bin/send_email.rs
@@ -141,6 +141,7 @@ async fn send_email(
                 is_sent: Some(true),
                 replied: None,
                 opened: None,
+                reply: None,
             },
         ) {
             log::error!(

--- a/src/models/email.rs
+++ b/src/models/email.rs
@@ -49,6 +49,7 @@ pub struct EmailRecipient {
     pub is_sent: bool,
     pub replied: bool,
     pub name: Option<String>,
+    pub reply: Option<String>,
 }
 
 #[derive(Insertable)]
@@ -105,6 +106,7 @@ impl From<EmailRecipient> for domain::EmailRecipient {
             is_sent: value.is_sent,
             replied: value.replied,
             name: value.name,
+            reply: value.reply,
         }
     }
 }

--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -241,6 +241,14 @@ impl EmailWriter for DieselRepository {
                 ))
                 .execute(&mut conn)?;
         }
+        if let Some(ref reply_text) = updates.reply {
+            diesel::update(email_recipients::table.filter(email_recipients::id.eq(recipient_id)))
+                .set((
+                    email_recipients::reply.eq(Some(reply_text.as_str())),
+                    email_recipients::updated_at.eq(chrono::Utc::now().naive_utc()),
+                ))
+                .execute(&mut conn)?;
+        }
 
         // Recalculate num_opened, num_sent, num_replied for emails::table
         let num_sent = email_recipients::table

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -210,6 +210,7 @@ pub async fn track_email(
                 opened: Some(true),
                 is_sent: Some(true),
                 replied: None,
+                reply: None,
             },
         )
         .is_err()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,6 +10,7 @@ diesel::table! {
         is_sent -> Bool,
         replied -> Bool,
         name -> Nullable<Text>,
+        reply -> Nullable<Text>,
     }
 }
 

--- a/templates/main/email.html
+++ b/templates/main/email.html
@@ -47,23 +47,24 @@
                     {{ email.message | safe }}
                 </div>
                 <div class="col">
-                    <ul>
+                    <ol class="list-group list-group-numbered">
                         {% for recipient in recipients %}
-                            <li class="{% if recipient.is_sent %}text-success{% endif %}">
-                                {{ recipient.address }}
-                                {% if recipient.opened %}
-                                    <i class="bi bi-envelope-check-fill" title="Сообщение просмотрено"></i>
-                                {% else %}
-                                    <i class="bi bi-envelope-check" title="Сообщение не просмотрено"></i>
-                                {% endif %}
-                                {% if recipient.replied %}
-                                    <i class="bi bi-reply-fill" title="Получен ответ на сообщение"></i>
-                                {% else %}
-                                    <i class="bi bi-reply" title="Ответ на сообщение не получен"></i>
-                                {% endif %}
+                            <li class="list-group-item d-flex justify-content-between align-items-start {% if recipient.is_sent %}text-success{% endif %}">
+                                <div class="ms-2 me-auto">
+                                    <div class="fw-bold">{{ recipient.address }}</div>
+                                    <div>{{recipient.reply | default(value="") | truncate(length=100) }}</div>
+                                </div>
+                                <span class="badge text-bg-primary rounded-pill">
+                                    {% if recipient.opened %}
+                                        <i class="bi bi-envelope-check-fill" title="Сообщение просмотрено"></i>
+                                    {% endif %}
+                                    {% if recipient.replied %}
+                                        <i class="bi bi-reply-fill" title="Получен ответ на сообщение"></i>
+                                    {% endif %}
+                                </span>
                             </li>
                         {% endfor %}
-                    </ul>
+                    </ol>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- fetch reply bodies via IMAP and log them
- report message contents during startup reply checks

## Testing
- `cargo fmt -- --check`
- `cargo clippy --bin check_reply --features send-email -- -Dwarnings`
- `cargo test --bin check_reply --features send-email --verbose`
- `cargo build --bin check_reply --features send-email --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b56822f980832ab71c1353d0aba410