### PR TITLE
Refactor repository queries to remove duplication

### DIFF
--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -9,6 +9,7 @@ use pushkind_common::models::emailer::email::{
 };
 use pushkind_common::repository::errors::RepositoryResult;
 
+use super::helpers::apply_pagination;
 use crate::repository::EmailListQuery;
 use crate::repository::{DieselRepository, EmailReader, EmailWriter};
 
@@ -60,13 +61,7 @@ impl EmailReader for DieselRepository {
         let total = query_builder().count().get_result::<i64>(&mut conn)? as usize;
 
         let mut items = query_builder();
-
-        // Apply pagination if requested
-        if let Some(pagination) = &query.pagination {
-            let offset = ((pagination.page.max(1) - 1) * pagination.per_page) as i64;
-            let limit = pagination.per_page as i64;
-            items = items.offset(offset).limit(limit);
-        }
+        items = apply_pagination(items, query.pagination.as_ref());
 
         let db_emails = items
             .order(emails::created_at.desc())

--- a/src/repository/group.rs
+++ b/src/repository/group.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
 use diesel::prelude::*;
 use pushkind_common::repository::errors::RepositoryResult;
 
+use super::helpers::{apply_pagination, hydrate_recipients};
 use crate::domain::group::{Group as DomainGroup, GroupWithRecipients, NewGroup as DomainNewGroup};
-use crate::domain::recipient::Recipient as DomainRecipient;
 use crate::models::group::{Group as DbGroup, GroupRecipient, NewGroup as DbNewGroup};
-use crate::models::recipient::{Recipient as DbRecipient, RecipientField};
+use crate::models::recipient::Recipient as DbRecipient;
 use crate::repository::{DieselRepository, GroupListQuery, GroupReader, GroupWriter};
 
 impl GroupReader for DieselRepository {
@@ -15,9 +13,7 @@ impl GroupReader for DieselRepository {
         id: i32,
         hub_id: i32,
     ) -> RepositoryResult<Option<GroupWithRecipients>> {
-        use pushkind_common::schema::emailer::{
-            groups, groups_recipients, recipients, unsubscribes,
-        };
+        use pushkind_common::schema::emailer::{groups, groups_recipients, recipients};
         let mut conn = self.conn()?;
 
         // Load group by id
@@ -40,68 +36,7 @@ impl GroupReader for DieselRepository {
             .select(DbRecipient::as_select())
             .load(&mut conn)?;
 
-        if db_recipients.is_empty() {
-            return Ok(Some(GroupWithRecipients {
-                group: DomainGroup::from(db_group),
-                recipients: vec![],
-            }));
-        }
-
-        let recipient_emails: Vec<String> = db_recipients
-            .iter()
-            .map(|recipient| recipient.email.clone())
-            .collect();
-
-        let unsubscribed_lookup = if recipient_emails.is_empty() {
-            HashMap::new()
-        } else {
-            unsubscribes::table
-                .filter(unsubscribes::hub_id.eq(hub_id))
-                .filter(unsubscribes::email.eq_any(&recipient_emails))
-                .select((unsubscribes::email, unsubscribes::created_at))
-                .load::<(String, chrono::NaiveDateTime)>(&mut conn)?
-                .into_iter()
-                .collect::<HashMap<_, _>>()
-        };
-
-        // Load recipient fields grouped by recipient
-        let db_fields = RecipientField::belonging_to(&db_recipients)
-            .select(RecipientField::as_select())
-            .load::<RecipientField>(&mut conn)?
-            .grouped_by(&db_recipients);
-
-        // Load group memberships for each recipient
-        let db_group_links = GroupRecipient::belonging_to(&db_recipients)
-            .select(GroupRecipient::as_select())
-            .load::<GroupRecipient>(&mut conn)?;
-
-        let mut recipient_to_group_ids: HashMap<i32, Vec<i32>> = HashMap::new();
-        for link in db_group_links {
-            recipient_to_group_ids
-                .entry(link.recipient_id)
-                .or_default()
-                .push(link.group_id);
-        }
-
-        // Compose domain recipients
-        let recipients = db_recipients
-            .into_iter()
-            .zip(db_fields)
-            .map(|(r, fields)| DomainRecipient {
-                unsubscribed_at: unsubscribed_lookup.get(&r.email).copied(),
-                id: r.id,
-                name: r.name,
-                email: r.email,
-                hub_id: r.hub_id,
-                created_at: r.created_at,
-                updated_at: r.updated_at,
-                fields: fields
-                    .into_iter()
-                    .map(|f| (f.field, f.value))
-                    .collect::<HashMap<_, _>>(),
-                groups: recipient_to_group_ids.remove(&r.id).unwrap_or_default(),
-            })
-            .collect();
+        let recipients = hydrate_recipients(&mut conn, hub_id, db_recipients)?;
 
         Ok(Some(GroupWithRecipients {
             group: DomainGroup::from(db_group),
@@ -123,13 +58,7 @@ impl GroupReader for DieselRepository {
         let total = query_builder().count().get_result::<i64>(&mut conn)? as usize;
 
         let mut items = query_builder();
-
-        // Apply pagination if requested
-        if let Some(pagination) = &query.pagination {
-            let offset = ((pagination.page.max(1) - 1) * pagination.per_page) as i64;
-            let limit = pagination.per_page as i64;
-            items = items.offset(offset).limit(limit);
-        }
+        items = apply_pagination(items, query.pagination.as_ref());
 
         // Final load
         let items = items

--- a/src/repository/helpers.rs
+++ b/src/repository/helpers.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+use diesel::prelude::*;
+use diesel::query_dsl::methods::{LimitDsl, OffsetDsl};
+
+use pushkind_common::db::DbConnection;
+use pushkind_common::pagination::Pagination;
+use pushkind_common::repository::errors::RepositoryResult;
+
+use crate::domain::recipient::Recipient as DomainRecipient;
+use crate::models::group::GroupRecipient;
+use crate::models::recipient::{Recipient as DbRecipient, RecipientField};
+
+pub(super) fn apply_pagination<T>(mut query: T, pagination: Option<&Pagination>) -> T
+where
+    T: OffsetDsl<Output = T> + LimitDsl<Output = T>,
+{
+    if let Some(pagination) = pagination {
+        let offset = ((pagination.page.max(1) - 1) * pagination.per_page) as i64;
+        let limit = pagination.per_page as i64;
+        query = query.offset(offset).limit(limit);
+    }
+
+    query
+}
+
+pub(super) fn hydrate_recipients(
+    conn: &mut DbConnection,
+    hub_id: i32,
+    db_recipients: Vec<DbRecipient>,
+) -> RepositoryResult<Vec<DomainRecipient>> {
+    use pushkind_common::schema::emailer::unsubscribes;
+
+    if db_recipients.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let recipient_emails: Vec<String> = db_recipients
+        .iter()
+        .map(|recipient| recipient.email.clone())
+        .collect();
+
+    let unsubscribed_lookup = if recipient_emails.is_empty() {
+        HashMap::new()
+    } else {
+        unsubscribes::table
+            .filter(unsubscribes::hub_id.eq(hub_id))
+            .filter(unsubscribes::email.eq_any(&recipient_emails))
+            .select((unsubscribes::email, unsubscribes::created_at))
+            .load::<(String, chrono::NaiveDateTime)>(conn)?
+            .into_iter()
+            .collect::<HashMap<_, _>>()
+    };
+
+    let db_fields = RecipientField::belonging_to(&db_recipients)
+        .select(RecipientField::as_select())
+        .load::<RecipientField>(conn)?
+        .grouped_by(&db_recipients);
+
+    let db_group_recipients = GroupRecipient::belonging_to(&db_recipients)
+        .select(GroupRecipient::as_select())
+        .load::<GroupRecipient>(conn)?;
+
+    let mut recipient_id_to_group_ids: HashMap<i32, Vec<i32>> = HashMap::new();
+    for relation in db_group_recipients {
+        recipient_id_to_group_ids
+            .entry(relation.recipient_id)
+            .or_default()
+            .push(relation.group_id);
+    }
+
+    let recipients = db_recipients
+        .into_iter()
+        .zip(db_fields)
+        .map(|(r, fields)| {
+            let unsubscribed_at = unsubscribed_lookup.get(&r.email).copied();
+            let groups = recipient_id_to_group_ids.remove(&r.id).unwrap_or_default();
+            DomainRecipient {
+                unsubscribed_at,
+                id: r.id,
+                name: r.name,
+                email: r.email,
+                hub_id: r.hub_id,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+                fields: fields
+                    .into_iter()
+                    .map(|f| (f.field, f.value))
+                    .collect::<HashMap<_, _>>(),
+                groups,
+            }
+        })
+        .collect();
+
+    Ok(recipients)
+}

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -7,6 +7,8 @@ use pushkind_common::repository::errors::RepositoryResult;
 use crate::domain::group::{Group, GroupWithRecipients, NewGroup};
 use crate::domain::recipient::{NewRecipient, Recipient, RecipientWithGroups, UpdateRecipient};
 
+mod helpers;
+
 pub mod email;
 pub mod group;
 pub mod hub;

--- a/src/repository/recipient.rs
+++ b/src/repository/recipient.rs
@@ -6,6 +6,7 @@ use diesel::upsert::excluded;
 use pushkind_common::repository::build_fts_match_query;
 use pushkind_common::repository::errors::{RepositoryError, RepositoryResult};
 
+use super::helpers::{apply_pagination, hydrate_recipients};
 use crate::domain::recipient::{
     NewRecipient as DomainNewRecipient, Recipient as DomainRecipient, RecipientWithGroups,
     UpdateRecipient as DomainUpdateRecipient,
@@ -72,7 +73,7 @@ impl RecipientReader for DieselRepository {
         &self,
         query: RecipientListQuery,
     ) -> RepositoryResult<(usize, Vec<DomainRecipient>)> {
-        use pushkind_common::schema::emailer::{groups_recipients, recipients, unsubscribes};
+        use pushkind_common::schema::emailer::{groups_recipients, recipients};
         let mut conn = self.conn()?;
 
         let query_builder = || {
@@ -100,77 +101,11 @@ impl RecipientReader for DieselRepository {
         let total = query_builder().count().get_result::<i64>(&mut conn)? as usize;
 
         let mut items = query_builder();
-
-        // Apply pagination if requested
-        if let Some(pagination) = &query.pagination {
-            let offset = ((pagination.page.max(1) - 1) * pagination.per_page) as i64;
-            let limit = pagination.per_page as i64;
-            items = items.offset(offset).limit(limit);
-        }
+        items = apply_pagination(items, query.pagination.as_ref());
 
         // Load recipients for the hub
         let db_recipients: Vec<Recipient> = items.order(recipients::name.desc()).load(&mut conn)?;
-
-        if db_recipients.is_empty() {
-            return Ok((total, Vec::new()));
-        }
-
-        let recipient_emails: Vec<String> = db_recipients
-            .iter()
-            .map(|recipient| recipient.email.clone())
-            .collect();
-
-        let unsubscribed_lookup = if recipient_emails.is_empty() {
-            HashMap::new()
-        } else {
-            unsubscribes::table
-                .filter(unsubscribes::hub_id.eq(query.hub_id))
-                .filter(unsubscribes::email.eq_any(&recipient_emails))
-                .select((unsubscribes::email, unsubscribes::created_at))
-                .load::<(String, chrono::NaiveDateTime)>(&mut conn)?
-                .into_iter()
-                .collect::<HashMap<_, _>>()
-        };
-
-        // Load recipient fields, grouped by recipient
-        let db_fields = RecipientField::belonging_to(&db_recipients)
-            .select(RecipientField::as_select())
-            .load::<RecipientField>(&mut conn)?
-            .grouped_by(&db_recipients);
-
-        // Load group-recipient relations
-        let db_group_recipients = GroupRecipient::belonging_to(&db_recipients)
-            .select(GroupRecipient::as_select())
-            .load::<GroupRecipient>(&mut conn)?;
-
-        // Build a map from recipient_id to group IDs
-        let mut recipient_id_to_group_ids: HashMap<i32, Vec<i32>> = HashMap::new();
-        for relation in db_group_recipients {
-            recipient_id_to_group_ids
-                .entry(relation.recipient_id)
-                .or_default()
-                .push(relation.group_id);
-        }
-
-        // Compose DomainRecipient
-        let recipients: Vec<DomainRecipient> = db_recipients
-            .into_iter()
-            .zip(db_fields)
-            .map(|(r, fields)| DomainRecipient {
-                unsubscribed_at: unsubscribed_lookup.get(&r.email).copied(),
-                id: r.id,
-                name: r.name,
-                email: r.email,
-                hub_id: r.hub_id,
-                created_at: r.created_at,
-                updated_at: r.updated_at,
-                fields: fields
-                    .into_iter()
-                    .map(|f| (f.field, f.value))
-                    .collect::<HashMap<_, _>>(),
-                groups: recipient_id_to_group_ids.remove(&r.id).unwrap_or_default(),
-            })
-            .collect();
+        let recipients = hydrate_recipients(&mut conn, query.hub_id, db_recipients)?;
 
         Ok((total, recipients))
     }
@@ -180,7 +115,6 @@ impl RecipientReader for DieselRepository {
         query: RecipientListQuery,
     ) -> RepositoryResult<(usize, Vec<DomainRecipient>)> {
         use crate::models::recipient::RecipientCount;
-        use pushkind_common::schema::emailer::unsubscribes;
 
         let mut conn = self.conn()?;
 
@@ -233,67 +167,7 @@ impl RecipientReader for DieselRepository {
         let db_recipients = data_query.load::<Recipient>(&mut conn)?;
 
         let total = total_query.get_result::<RecipientCount>(&mut conn)?.count as usize;
-
-        if db_recipients.is_empty() {
-            return Ok((total, Vec::new()));
-        }
-
-        let recipient_emails: Vec<String> = db_recipients
-            .iter()
-            .map(|recipient| recipient.email.clone())
-            .collect();
-
-        let unsubscribed_lookup = if recipient_emails.is_empty() {
-            HashMap::new()
-        } else {
-            unsubscribes::table
-                .filter(unsubscribes::hub_id.eq(query.hub_id))
-                .filter(unsubscribes::email.eq_any(&recipient_emails))
-                .select((unsubscribes::email, unsubscribes::created_at))
-                .load::<(String, chrono::NaiveDateTime)>(&mut conn)?
-                .into_iter()
-                .collect::<HashMap<_, _>>()
-        };
-
-        // Load recipient fields, grouped by recipient
-        let db_fields = RecipientField::belonging_to(&db_recipients)
-            .select(RecipientField::as_select())
-            .load::<RecipientField>(&mut conn)?
-            .grouped_by(&db_recipients);
-
-        // Load group-recipient relations
-        let db_group_recipients = GroupRecipient::belonging_to(&db_recipients)
-            .select(GroupRecipient::as_select())
-            .load::<GroupRecipient>(&mut conn)?;
-
-        // Build a map from recipient_id to group IDs
-        let mut recipient_id_to_group_ids: HashMap<i32, Vec<i32>> = HashMap::new();
-        for relation in db_group_recipients {
-            recipient_id_to_group_ids
-                .entry(relation.recipient_id)
-                .or_default()
-                .push(relation.group_id);
-        }
-
-        // Compose DomainRecipient
-        let recipients: Vec<DomainRecipient> = db_recipients
-            .into_iter()
-            .zip(db_fields)
-            .map(|(r, fields)| DomainRecipient {
-                unsubscribed_at: unsubscribed_lookup.get(&r.email).copied(),
-                id: r.id,
-                name: r.name,
-                email: r.email,
-                hub_id: r.hub_id,
-                created_at: r.created_at,
-                updated_at: r.updated_at,
-                fields: fields
-                    .into_iter()
-                    .map(|f| (f.field, f.value))
-                    .collect::<HashMap<_, _>>(),
-                groups: recipient_id_to_group_ids.remove(&r.id).unwrap_or_default(),
-            })
-            .collect();
+        let recipients = hydrate_recipients(&mut conn, query.hub_id, db_recipients)?;
 
         Ok((total, recipients))
     }


### PR DESCRIPTION
## Summary
- add a shared repository helper module for pagination and recipient hydration
- update email, group, and recipient Diesel queries to reuse the new helpers and remove duplicated logic

## Testing
- cargo build --all-features --verbose
- cargo test --all-features --verbose
- cargo clippy --all-features --tests -- -Dwarnings
- cargo fmt --all -- --check

------
https://chatgpt.com/codex/tasks/task_e_68c9bd0feb10832aaa5b7df9ea75a98a