### PR TITLE
Add Diesel repository support for grouped email recipients

### DIFF
--- a/src/domain/recipient.rs
+++ b/src/domain/recipient.rs
@@ -107,6 +107,7 @@ pub struct CSVExportRecipient {
     pub opened: bool,
     pub sent: bool,
     pub replied: bool,
+    pub updated_at: NaiveDateTime,
 }
 
 impl From<EmailRecipient> for CSVExportRecipient {
@@ -117,6 +118,7 @@ impl From<EmailRecipient> for CSVExportRecipient {
             opened: value.opened,
             sent: value.is_sent,
             replied: value.replied,
+            updated_at: value.updated_at,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ use pushkind_emailer::routes::recipients::{
     recipients_add, recipients_clean, recipients_delete, recipients_modal, recipients_save,
     recipients_show, recipients_source, recipients_upload,
 };
-use pushkind_emailer::routes::settings::{settings_save, settings_show, unsubscribed_show};
+use pushkind_emailer::routes::settings::{
+    history_show, settings_save, settings_show, unsubscribed_show,
+};
 
 /// Application entry point launching the Actix Web server.
 #[actix_web::main]
@@ -136,7 +138,8 @@ async fn main() -> std::io::Result<()> {
                     .service(groups_delete)
                     .service(groups_assign)
                     .service(groups_modal)
-                    .service(unsubscribed_show),
+                    .service(unsubscribed_show)
+                    .service(history_show),
             )
             .app_data(web::Data::new(tera.clone()))
             .app_data(web::Data::new(repo.clone()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use pushkind_emailer::routes::recipients::{
     recipients_show, recipients_source, recipients_upload,
 };
 use pushkind_emailer::routes::settings::{
-    history_show, settings_save, settings_show, unsubscribed_show,
+    history_download, history_show, settings_save, settings_show, unsubscribed_show,
 };
 
 /// Application entry point launching the Actix Web server.
@@ -139,7 +139,8 @@ async fn main() -> std::io::Result<()> {
                     .service(groups_assign)
                     .service(groups_modal)
                     .service(unsubscribed_show)
-                    .service(history_show),
+                    .service(history_show)
+                    .service(history_download),
             )
             .app_data(web::Data::new(tera.clone()))
             .app_data(web::Data::new(repo.clone()))

--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use diesel::prelude::*;
 use pushkind_common::domain::emailer::email::{
     EmailRecipient as DomainEmailRecipient, EmailWithRecipients as DomainEmailWithRecipients,
@@ -100,32 +102,28 @@ impl EmailRecipientReader for DieselRepository {
 
         let mut conn = self.conn()?;
 
-        let rows: Vec<(i32, DbEmailRecipient)> = email_recipients::table
+        // Step 1: Load all rows sorted so newest per address comes first
+        let rows: Vec<DbEmailRecipient> = email_recipients::table
             .inner_join(emails::table)
             .filter(emails::hub_id.eq(hub_id))
-            .select((emails::hub_id, DbEmailRecipient::as_select()))
             .order((
-                emails::hub_id.asc(),
                 email_recipients::address.asc(),
                 email_recipients::updated_at.desc(),
-                email_recipients::id.desc(),
             ))
+            .select(DbEmailRecipient::as_select())
             .load(&mut conn)?;
 
-        let mut latest: Vec<DbEmailRecipient> = Vec::new();
-        let mut last_key: Option<(i32, String)> = None;
-
-        for (row_hub_id, recipient) in rows {
-            let is_same_group = last_key
-                .as_ref()
-                .map(|(hub, address)| *hub == row_hub_id && address == &recipient.address)
-                .unwrap_or(false);
-
-            if !is_same_group {
-                last_key = Some((row_hub_id, recipient.address.clone()));
-                latest.push(recipient);
+        // Step 2: Keep only the first row per address
+        let mut seen = HashSet::new();
+        let mut latest = Vec::with_capacity(rows.len());
+        for r in rows {
+            if seen.insert(r.address.clone()) {
+                latest.push(r);
             }
         }
+
+        // Step 3: Sort the final set by updated_at descending
+        latest.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
 
         Ok(latest.into_iter().map(Into::into).collect())
     }

--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -1,6 +1,6 @@
 use diesel::prelude::*;
 use pushkind_common::domain::emailer::email::{
-    EmailWithRecipients as DomainEmailWithRecipients,
+    EmailRecipient as DomainEmailRecipient, EmailWithRecipients as DomainEmailWithRecipients,
     UpdateEmailRecipient as DomainUpdateEmailRecipient,
 };
 use pushkind_common::models::emailer::email::{
@@ -10,8 +10,9 @@ use pushkind_common::models::emailer::email::{
 use pushkind_common::repository::errors::RepositoryResult;
 
 use super::helpers::apply_pagination;
-use crate::repository::EmailListQuery;
-use crate::repository::{DieselRepository, EmailReader, EmailWriter};
+use crate::repository::{
+    DieselRepository, EmailListQuery, EmailReader, EmailRecipientReader, EmailWriter,
+};
 
 impl EmailReader for DieselRepository {
     fn get_email_by_id(
@@ -90,6 +91,46 @@ impl EmailReader for DieselRepository {
     }
 }
 
+impl EmailRecipientReader for DieselRepository {
+    fn list_recipients_grouped_by_address(
+        &self,
+        hub_id: i32,
+    ) -> RepositoryResult<Vec<DomainEmailRecipient>> {
+        use pushkind_common::schema::emailer::{email_recipients, emails};
+
+        let mut conn = self.conn()?;
+
+        let rows: Vec<(i32, DbEmailRecipient)> = email_recipients::table
+            .inner_join(emails::table)
+            .filter(emails::hub_id.eq(hub_id))
+            .select((emails::hub_id, DbEmailRecipient::as_select()))
+            .order((
+                emails::hub_id.asc(),
+                email_recipients::address.asc(),
+                email_recipients::updated_at.desc(),
+                email_recipients::id.desc(),
+            ))
+            .load(&mut conn)?;
+
+        let mut latest: Vec<DbEmailRecipient> = Vec::new();
+        let mut last_key: Option<(i32, String)> = None;
+
+        for (row_hub_id, recipient) in rows {
+            let is_same_group = last_key
+                .as_ref()
+                .map(|(hub, address)| *hub == row_hub_id && address == &recipient.address)
+                .unwrap_or(false);
+
+            if !is_same_group {
+                last_key = Some((row_hub_id, recipient.address.clone()));
+                latest.push(recipient);
+            }
+        }
+
+        Ok(latest.into_iter().map(Into::into).collect())
+    }
+}
+
 impl EmailWriter for DieselRepository {
     fn update_recipient(
         &self,
@@ -133,5 +174,167 @@ impl EmailWriter for DieselRepository {
             .execute(&mut conn)?;
         diesel::delete(emails::table.filter(emails::id.eq(id))).execute(&mut conn)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::{DieselRepository, EmailRecipientReader};
+    use diesel::connection::SimpleConnection;
+    use pushkind_common::db::establish_connection_pool;
+    use tempfile::tempdir;
+
+    #[test]
+    fn list_recipients_grouped_by_address_returns_latest_snapshot() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        let db_path = db_path.to_string_lossy().to_string();
+        let pool = establish_connection_pool(&db_path).unwrap();
+
+        {
+            let mut conn = pool.get().unwrap();
+
+            conn.batch_execute(
+                r#"
+                CREATE TABLE hubs (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL
+                );
+                "#,
+            )
+            .unwrap();
+
+            conn.batch_execute(
+                r#"
+                CREATE TABLE emails (
+                    id INTEGER PRIMARY KEY,
+                    message TEXT NOT NULL,
+                    created_at TIMESTAMP NOT NULL,
+                    is_sent BOOLEAN NOT NULL,
+                    subject TEXT,
+                    attachment BLOB,
+                    attachment_name TEXT,
+                    attachment_mime TEXT,
+                    num_sent INTEGER NOT NULL,
+                    num_opened INTEGER NOT NULL,
+                    num_replied INTEGER NOT NULL,
+                    hub_id INTEGER NOT NULL REFERENCES hubs(id)
+                );
+                "#,
+            )
+            .unwrap();
+
+            conn.batch_execute(
+                r#"
+                CREATE TABLE email_recipients (
+                    id INTEGER PRIMARY KEY,
+                    email_id INTEGER NOT NULL REFERENCES emails(id),
+                    address TEXT NOT NULL,
+                    opened BOOLEAN NOT NULL,
+                    updated_at TIMESTAMP NOT NULL,
+                    is_sent BOOLEAN NOT NULL,
+                    replied BOOLEAN NOT NULL,
+                    reply TEXT,
+                    name TEXT NOT NULL,
+                    fields TEXT NOT NULL
+                );
+                "#,
+            )
+            .unwrap();
+
+            conn.batch_execute(
+                r#"
+                INSERT INTO hubs (id, name) VALUES (1, 'Hub 1'), (2, 'Hub 2');
+                "#,
+            )
+            .unwrap();
+
+            conn.batch_execute(
+                r#"
+                INSERT INTO emails (
+                    id,
+                    message,
+                    created_at,
+                    is_sent,
+                    subject,
+                    attachment,
+                    attachment_name,
+                    attachment_mime,
+                    num_sent,
+                    num_opened,
+                    num_replied,
+                    hub_id
+                )
+                VALUES
+                    (1, 'Msg', '2024-01-01 00:00:00', 0, NULL, NULL, NULL, NULL, 0, 0, 0, 1),
+                    (2, 'Msg', '2024-01-02 00:00:00', 0, NULL, NULL, NULL, NULL, 0, 0, 0, 1),
+                    (3, 'Msg', '2024-01-03 00:00:00', 0, NULL, NULL, NULL, NULL, 0, 0, 0, 2);
+                "#,
+            )
+            .unwrap();
+
+            conn.batch_execute(
+                r#"
+                INSERT INTO email_recipients (
+                    id,
+                    email_id,
+                    address,
+                    opened,
+                    updated_at,
+                    is_sent,
+                    replied,
+                    reply,
+                    name,
+                    fields
+                )
+                VALUES
+                    (1, 1, 'a@example.com', 0, '2024-01-01 10:00:00', 0, 0, NULL, 'Old A', '{"segment":"old"}'),
+                    (2, 2, 'a@example.com', 1, '2024-01-02 10:00:00', 1, 1, 'Thanks', 'New A', '{"segment":"new"}'),
+                    (3, 2, 'b@example.com', 0, '2024-01-01 11:00:00', 0, 0, NULL, 'Bee', '{"segment":"bee"}'),
+                    (4, 3, 'a@example.com', 1, '2024-01-03 12:00:00', 1, 0, NULL, 'Hub2 A', '{"segment":"hub2"}');
+                "#,
+            )
+            .unwrap();
+        }
+
+        let repo = DieselRepository::new(pool.clone());
+
+        let recipients = repo.list_recipients_grouped_by_address(1).unwrap();
+        assert_eq!(recipients.len(), 2);
+
+        let recipient_a = recipients
+            .iter()
+            .find(|recipient| recipient.address == "a@example.com")
+            .unwrap();
+        assert_eq!(recipient_a.email_id, 2);
+        assert!(recipient_a.opened);
+        assert!(recipient_a.is_sent);
+        assert!(recipient_a.replied);
+        assert_eq!(recipient_a.reply.as_deref(), Some("Thanks"));
+        assert_eq!(recipient_a.name, "New A");
+        assert_eq!(
+            recipient_a.fields.get("segment").map(String::as_str),
+            Some("new")
+        );
+
+        let recipient_b = recipients
+            .iter()
+            .find(|recipient| recipient.address == "b@example.com")
+            .unwrap();
+        assert_eq!(recipient_b.email_id, 2);
+        assert_eq!(recipient_b.name, "Bee");
+        assert_eq!(
+            recipient_b.fields.get("segment").map(String::as_str),
+            Some("bee")
+        );
+
+        let recipients_hub2 = repo.list_recipients_grouped_by_address(2).unwrap();
+        assert_eq!(recipients_hub2.len(), 1);
+        assert_eq!(recipients_hub2[0].address, "a@example.com");
+        assert_eq!(recipients_hub2[0].name, "Hub2 A");
+        assert_eq!(
+            recipients_hub2[0].fields.get("segment").map(String::as_str),
+            Some("hub2")
+        );
     }
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,5 +1,7 @@
 use pushkind_common::db::{DbConnection, DbPool};
-use pushkind_common::domain::emailer::email::{EmailWithRecipients, UpdateEmailRecipient};
+use pushkind_common::domain::emailer::email::{
+    EmailRecipient, EmailWithRecipients, UpdateEmailRecipient,
+};
 use pushkind_common::domain::emailer::hub::{Hub, NewHub, UpdateHub};
 use pushkind_common::pagination::Pagination;
 use pushkind_common::repository::errors::RepositoryResult;
@@ -155,6 +157,18 @@ pub trait EmailWriter {
         updates: &UpdateEmailRecipient,
     ) -> RepositoryResult<EmailWithRecipients>;
     fn delete_email(&self, id: i32) -> RepositoryResult<()>;
+}
+
+pub trait EmailRecipientReader {
+    /// Return recipients grouped by email address for the provided hub.
+    ///
+    /// When the same email address received multiple emails within the hub,
+    /// the record with the most recent `updated_at` timestamp is returned so
+    /// that caller always gets the latest snapshot of the recipient data.
+    fn list_recipients_grouped_by_address(
+        &self,
+        hub_id: i32,
+    ) -> RepositoryResult<Vec<EmailRecipient>>;
 }
 
 pub trait HubReader {

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -154,7 +154,7 @@ pub async fn history_download(
         .content_type("text/csv")
         .append_header((
             "Content-Disposition",
-            format!("attachment; filename=\"recipients_history.csv\""),
+            "attachment; filename=\"recipients_history.csv\"",
         ))
         .body(data)
 }

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -7,6 +7,7 @@ use pushkind_common::routes::{base_context, render_template};
 use pushkind_common::routes::{ensure_role, redirect};
 use tera::Tera;
 
+use crate::domain::recipient::CSVExportRecipient;
 use crate::forms::settings::SaveHubForm;
 use crate::repository::{
     DieselRepository, EmailRecipientReader, HubReader, HubWriter, RecipientReader,
@@ -113,6 +114,49 @@ pub async fn history_show(
     context.insert("history_list", &history_list);
 
     render_template(&tera, "settings/history.html", &context)
+}
+
+#[get("/history/download")]
+pub async fn history_download(
+    user: AuthenticatedUser,
+    repo: web::Data<DieselRepository>,
+) -> impl Responder {
+    if let Err(response) = ensure_role(&user, "emailer", Some("/na")) {
+        return response;
+    };
+
+    let history_list = match repo.list_recipients_grouped_by_address(user.hub_id) {
+        Ok(history_list) => history_list,
+        Err(e) => {
+            log::error!("Error getting history recipients: {e}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    let mut writer = csv::Writer::from_writer(vec![]);
+    for recipient in history_list {
+        let recipient = CSVExportRecipient::from(recipient);
+        if let Err(err) = writer.serialize(recipient) {
+            log::error!("Failed to write recipient to csv: {err}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    }
+
+    let data = match writer.into_inner() {
+        Ok(data) => data,
+        Err(err) => {
+            log::error!("Failed to finalize csv: {err}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/csv")
+        .append_header((
+            "Content-Disposition",
+            format!("attachment; filename=\"recipients_history.csv\""),
+        ))
+        .body(data)
 }
 
 #[post("/settings/save")]

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -8,7 +8,9 @@ use pushkind_common::routes::{ensure_role, redirect};
 use tera::Tera;
 
 use crate::forms::settings::SaveHubForm;
-use crate::repository::{DieselRepository, HubReader, HubWriter, RecipientReader};
+use crate::repository::{
+    DieselRepository, EmailRecipientReader, HubReader, HubWriter, RecipientReader,
+};
 
 #[get("/settings")]
 pub async fn settings_show(
@@ -79,6 +81,38 @@ pub async fn unsubscribed_show(
     context.insert("unsubscribed_list", &unsubscribed_list);
 
     render_template(&tera, "settings/unsubscribed.html", &context)
+}
+
+#[get("/history")]
+pub async fn history_show(
+    user: AuthenticatedUser,
+    flash_messages: IncomingFlashMessages,
+    repo: web::Data<DieselRepository>,
+    server_config: web::Data<CommonServerConfig>,
+    tera: web::Data<Tera>,
+) -> impl Responder {
+    if let Err(response) = ensure_role(&user, "emailer", Some("/na")) {
+        return response;
+    };
+
+    let mut context = base_context(
+        &flash_messages,
+        &user,
+        "history",
+        &server_config.auth_service_url,
+    );
+
+    let history_list = match repo.list_recipients_grouped_by_address(user.hub_id) {
+        Ok(history_list) => history_list,
+        Err(e) => {
+            log::error!("Error getting history recipients: {e}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    context.insert("history_list", &history_list);
+
+    render_template(&tera, "settings/history.html", &context)
 }
 
 #[post("/settings/save")]

--- a/templates/navigation.html
+++ b/templates/navigation.html
@@ -51,6 +51,12 @@
                         </a>
                     </li>
                     <li>
+                        <a class="dropdown-item icon-link" href="/history">
+                            <i class="bi bi-clock-history mb-2"></i>
+                            История
+                        </a>
+                    </li>
+                    <li>
                         <a class="dropdown-item icon-link" href="{{home_url}}">
                             <i class="bi bi-house mb-2"></i>
                             Домой

--- a/templates/settings/history.html
+++ b/templates/settings/history.html
@@ -10,7 +10,16 @@
             <div class="table-responsive">
                 <table class="table table-hover align-middle mb-0 caption-top">
                     <caption class="px-2">
-                        Отображается только дата последнего письма для каждого получателя
+                        <div class="row">
+                            <div class="col">
+                                Отображается только дата последнего письма для каждого получателя
+                            </div>
+                            <div class="col-auto">
+                                <a href="/history/download">
+                                    <i class="bi bi-download"></i>
+                                </a>
+                            </div>
+                        </div>
                     </caption>
                     <thead class="table-light">
                         <tr>

--- a/templates/settings/history.html
+++ b/templates/settings/history.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+
+{% block content %}
+{% include 'navigation.html' %}
+
+
+<div class="container py-4">
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0 caption-top">
+                    <caption class="px-2">
+                        Отображается только дата последнего письма для каждого получателя
+                    </caption>
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col" style="width: 40%">Получатель</th>
+                            <th scope="col" style="width: 20%">Дата</th>
+                            <th scope="col" style="width: 20%">Просмотрено</th>
+                            <th scope="col" style="width: 20%">Отвечено</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for history in history_list %}
+                        <tr>
+                            <td>
+                                {% if history.name %}
+                                {{history.name}}<br>
+                                {% endif %}
+                                <i class="bi-envelope me-1" aria-hidden="true"></i>
+                                <a href="mailto:{{history.address}}">
+                                    {{history.address}}
+                                </a>
+                            </td>
+                            <td>
+                                <time datetime="{{history.updated_at}}">
+                                    {{history.updated_at | date(format="%Y-%m-%d %H:%M")}}
+                                </time>
+                            </td>
+                            <td>
+                                {% if history.opened %}
+                                <i class="bi bi-plus-circle"></i>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if history.replied %}
+                                <i class="bi bi-plus-circle"></i>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="card-footer d-flex justify-content-between align-items-center">
+            <div class="text-muted small">
+                <i class="bi-info-circle me-1" aria-hidden="true"></i>
+                Всего {{history_list | length}} получателей.
+            </div>
+        </div>
+    </div>
+</div>
+
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an `EmailRecipientReader` repository trait for grouped recipient lookups
- implement the Diesel query to return the latest recipient per (hub, address)
- cover the grouping behavior with an integration-style test using SQLite

## Testing
- cargo fmt
- cargo test --all-features --verbose
- cargo clippy --all-features --tests -- -Dwarnings

------
https://chatgpt.com/codex/tasks/task_e_68ce9e457768832ab442be72c11fdcfb