### PR TITLE
Add cooldown filtering for send email form

### DIFF
--- a/src/forms/main.rs
+++ b/src/forms/main.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use actix_multipart::form::{MultipartForm, json::Json as MpJson, tempfile::TempFile, text::Text};
-use chrono::{Duration, Utc};
 use pushkind_common::{
-    domain::emailer::email::{EmailRecipient, NewEmail, NewEmailRecipient},
+    domain::emailer::email::{NewEmail, NewEmailRecipient},
     repository::errors::RepositoryResult,
 };
 use serde::Deserialize;
@@ -104,48 +103,14 @@ impl SendEmailForm {
         recipients.dedup_by(|a, b| a.address == b.address);
 
         if let Some(days) = cooldown_days.filter(|d| *d > 0) {
-            let history = repo.list_recipients_grouped_by_address(hub_id)?;
-            if !history.is_empty() {
-                let latest: HashMap<String, EmailRecipient> = history
-                    .into_iter()
-                    .map(|recipient| (recipient.address.clone(), recipient))
-                    .collect();
+            let recent_addresses: HashSet<String> = repo
+                .list_recent_recipients(hub_id, Some(days))?
+                .into_iter()
+                .map(|recipient| recipient.address)
+                .collect();
 
-                let mut send_times = HashMap::new();
-                for entry in latest.values().filter(|entry| entry.is_sent) {
-                    if send_times.contains_key(&entry.email_id) {
-                        continue;
-                    }
-
-                    match repo.get_email_by_id(entry.email_id, hub_id)? {
-                        Some(email) => {
-                            send_times.insert(entry.email_id, email.email.created_at);
-                        }
-                        None => {
-                            log::warn!(
-                                "expected to find email {} for cooldown check but none was returned",
-                                entry.email_id
-                            );
-                        }
-                    }
-                }
-
-                let cutoff = (Utc::now() - Duration::days(days)).naive_utc();
-                recipients.retain(|recipient| {
-                    latest
-                        .get(&recipient.address)
-                        .map(|entry| {
-                            if !entry.is_sent {
-                                true
-                            } else {
-                                send_times
-                                    .get(&entry.email_id)
-                                    .map(|sent_at| *sent_at < cutoff)
-                                    .unwrap_or(true)
-                            }
-                        })
-                        .unwrap_or(true)
-                });
+            if !recent_addresses.is_empty() {
+                recipients.retain(|recipient| !recent_addresses.contains(&recipient.address));
             }
         }
 

--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use chrono::NaiveDateTime;
+use chrono::{Duration, NaiveDateTime, Utc};
 use diesel::prelude::*;
 use pushkind_common::domain::emailer::email::{
     EmailRecipient as DomainEmailRecipient, EmailWithRecipients as DomainEmailWithRecipients,
@@ -95,18 +95,32 @@ impl EmailReader for DieselRepository {
 }
 
 impl EmailRecipientReader for DieselRepository {
-    fn list_recipients_grouped_by_address(
+    fn list_recent_recipients(
         &self,
         hub_id: i32,
+        // Only include recipients whose most recent email was sent strictly
+        // after `number_of_days` ago. `None` skips filtering.
+        number_of_days: Option<i64>,
     ) -> RepositoryResult<Vec<DomainEmailRecipient>> {
         use pushkind_common::schema::emailer::{email_recipients, emails};
 
         let mut conn = self.conn()?;
 
-        // Step 1: Load all rows sorted so newest per address comes first
-        let rows: Vec<(DbEmailRecipient, NaiveDateTime)> = email_recipients::table
+        // Build the base query (SQLite-compatible)
+        let mut query = email_recipients::table
             .inner_join(emails::table)
             .filter(emails::hub_id.eq(hub_id))
+            .into_boxed();
+
+        // Push the created_at cutoff into the DB
+        if let Some(days) = number_of_days.filter(|d| *d > 0) {
+            let cutoff = Utc::now().naive_utc() - Duration::days(days);
+            // keep emails strictly AFTER the cutoff
+            query = query.filter(emails::created_at.gt(cutoff));
+        }
+
+        // Step 1: Load all rows sorted so newest per address comes first
+        let rows: Vec<(DbEmailRecipient, NaiveDateTime)> = query
             .order((
                 email_recipients::address.asc(),
                 emails::created_at.desc(),
@@ -115,7 +129,7 @@ impl EmailRecipientReader for DieselRepository {
             .select((DbEmailRecipient::as_select(), emails::created_at))
             .load(&mut conn)?;
 
-        // Step 2: Keep only the first row per address
+        // Step 2: Keep only the first row per address (Rust-side dedup)
         let mut seen = HashSet::new();
         let mut latest = Vec::with_capacity(rows.len());
         for (recipient, email_created_at) in rows {
@@ -186,12 +200,12 @@ impl EmailWriter for DieselRepository {
 #[cfg(test)]
 mod tests {
     use crate::repository::{DieselRepository, EmailRecipientReader};
+    use chrono::{Duration, Utc};
     use diesel::connection::SimpleConnection;
-    use pushkind_common::db::establish_connection_pool;
-    use tempfile::tempdir;
+    use pushkind_common::db::{DbPool, establish_connection_pool};
+    use tempfile::{TempDir, tempdir};
 
-    #[test]
-    fn list_recipients_grouped_by_address_returns_latest_snapshot() {
+    fn setup_db() -> (TempDir, DbPool) {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("test.sqlite");
         let db_path = db_path.to_string_lossy().to_string();
@@ -247,6 +261,17 @@ mod tests {
                 "#,
             )
             .unwrap();
+        }
+
+        (dir, pool)
+    }
+
+    #[test]
+    fn list_recent_recipients_returns_latest_snapshot() {
+        let (_dir, pool) = setup_db();
+
+        {
+            let mut conn = pool.get().unwrap();
 
             conn.batch_execute(
                 r#"
@@ -305,7 +330,7 @@ mod tests {
 
         let repo = DieselRepository::new(pool.clone());
 
-        let recipients = repo.list_recipients_grouped_by_address(1).unwrap();
+        let recipients = repo.list_recent_recipients(1, None).unwrap();
         assert_eq!(recipients.len(), 2);
 
         let recipient_a = recipients
@@ -334,7 +359,7 @@ mod tests {
             Some("bee")
         );
 
-        let recipients_hub2 = repo.list_recipients_grouped_by_address(2).unwrap();
+        let recipients_hub2 = repo.list_recent_recipients(2, None).unwrap();
         assert_eq!(recipients_hub2.len(), 1);
         assert_eq!(recipients_hub2[0].address, "a@example.com");
         assert_eq!(recipients_hub2[0].name, "Hub2 A");
@@ -342,5 +367,48 @@ mod tests {
             recipients_hub2[0].fields.get("segment").map(String::as_str),
             Some("hub2")
         );
+    }
+
+    #[test]
+    fn list_recent_recipients_applies_number_of_days_filter() {
+        let (_dir, pool) = setup_db();
+
+        let now = Utc::now().naive_utc();
+        let recent = now - Duration::hours(12);
+        let old = now - Duration::days(5);
+
+        {
+            let mut conn = pool.get().unwrap();
+
+            conn.batch_execute(
+                r#"
+                INSERT INTO hubs (id, name) VALUES (1, 'Hub 1');
+                "#,
+            )
+            .unwrap();
+
+            let insert_emails = format!(
+                "INSERT INTO emails (id, message, created_at, is_sent, subject, attachment, attachment_name, attachment_mime, num_sent, num_opened, num_replied, hub_id) VALUES
+                    (1, 'Msg', '{old}', 1, NULL, NULL, NULL, NULL, 0, 0, 0, 1),
+                    (2, 'Msg', '{recent}', 1, NULL, NULL, NULL, NULL, 0, 0, 0, 1);",
+            );
+            conn.batch_execute(&insert_emails).unwrap();
+
+            let insert_recipients = format!(
+                "INSERT INTO email_recipients (id, email_id, address, opened, updated_at, is_sent, replied, reply, name, fields) VALUES
+                    (1, 1, 'slow@example.com', 0, '{old}', 1, 0, NULL, 'Slow', '{{}}'),
+                    (2, 2, 'fast@example.com', 0, '{recent}', 1, 0, NULL, 'Fast', '{{}}');",
+            );
+            conn.batch_execute(&insert_recipients).unwrap();
+        }
+
+        let repo = DieselRepository::new(pool.clone());
+
+        let all = repo.list_recent_recipients(1, None).unwrap();
+        assert_eq!(all.len(), 2);
+
+        let filtered = repo.list_recent_recipients(1, Some(3)).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].address, "fast@example.com");
     }
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -165,9 +165,12 @@ pub trait EmailRecipientReader {
     /// When the same email address received multiple emails within the hub,
     /// the record belonging to the most recently created email is returned so
     /// that callers always get the latest snapshot of the recipient data.
-    fn list_recipients_grouped_by_address(
+    fn list_recent_recipients(
         &self,
         hub_id: i32,
+        // Only include recipients whose most recent email was sent strictly
+        // after `number_of_days` ago. `None` skips filtering.
+        number_of_days: Option<i64>,
     ) -> RepositoryResult<Vec<EmailRecipient>>;
 }
 

--- a/src/repository/test.rs
+++ b/src/repository/test.rs
@@ -58,9 +58,10 @@ impl RecipientReader for TestRepository {
 }
 
 impl EmailRecipientReader for TestRepository {
-    fn list_recipients_grouped_by_address(
+    fn list_recent_recipients(
         &self,
         _hub_id: i32,
+        _number_of_days: Option<i64>,
     ) -> RepositoryResult<Vec<EmailRecipient>> {
         Ok(vec![])
     }

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -17,6 +17,7 @@ use tera::Tera;
 
 use crate::domain::recipient::CSVExportRecipient;
 use crate::forms::main::{DeleteEmailForm, ResendEmailForm, SendEmailForm};
+use crate::models::config::ServerConfig;
 use crate::repository::{
     DieselRepository, EmailListQuery, EmailReader, EmailWriter, GroupListQuery, GroupReader,
     RecipientListQuery, RecipientReader,
@@ -34,7 +35,8 @@ pub async fn index(
     user: AuthenticatedUser,
     repo: web::Data<DieselRepository>,
     flash_messages: IncomingFlashMessages,
-    server_config: web::Data<CommonServerConfig>,
+    common_config: web::Data<CommonServerConfig>,
+    server_config: web::Data<ServerConfig>,
     tera: web::Data<Tera>,
 ) -> impl Responder {
     if let Err(response) = ensure_role(&user, "emailer", Some("/na")) {
@@ -50,7 +52,7 @@ pub async fn index(
         &flash_messages,
         &user,
         "index",
-        &server_config.auth_service_url,
+        &common_config.auth_service_url,
     );
     context.insert("retry", &retry);
 
@@ -97,6 +99,7 @@ pub async fn index(
     context.insert("groups", &groups);
     context.insert("emails", &emails);
     context.insert("custom_fields", &custom_fields);
+    context.insert("crm_service_url", &server_config.crm_service_url);
 
     render_template(&tera, "main/index.html", &context)
 }

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -103,7 +103,7 @@ pub async fn history_show(
         &server_config.auth_service_url,
     );
 
-    let history_list = match repo.list_recipients_grouped_by_address(user.hub_id) {
+    let history_list = match repo.list_recent_recipients(user.hub_id, None) {
         Ok(history_list) => history_list,
         Err(e) => {
             log::error!("Error getting history recipients: {e}");
@@ -125,7 +125,7 @@ pub async fn history_download(
         return response;
     };
 
-    let history_list = match repo.list_recipients_grouped_by_address(user.hub_id) {
+    let history_list = match repo.list_recent_recipients(user.hub_id, None) {
         Ok(history_list) => history_list,
         Err(e) => {
             log::error!("Error getting history recipients: {e}");

--- a/templates/main/email.html
+++ b/templates/main/email.html
@@ -61,7 +61,11 @@
                                 text-secondary
                             {% endif %}">
                             <div class="ms-2 me-auto">
-                                <div class="fw-bold">{{ recipient.address }}</div>
+                                <div class="fw-bold">
+                                    <a href="{{ crm_service_url }}?q={{ recipient.address }}">
+                                        {{ recipient.address }}
+                                    </a>
+                                </div>
                                 <div>{{recipient.reply | default(value="") | truncate(length=100) }}</div>
                             </div>
                             {% if recipient.is_sent or recipient.opened or recipient.replied %}

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -1,146 +1,142 @@
 {% extends 'base.html' %}
 
 {% block styles %}
-    <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.bootstrap4.min.css"
-        integrity="sha512-MMojOrCQrqLg4Iarid2YMYyZ7pzjPeXKRvhW9nZqLo6kPBBTuvNET9DBVWptAo/Q20Fy11EIHM5ig4WlIrJfQw=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-    />
+<link rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.bootstrap4.min.css"
+    integrity="sha512-MMojOrCQrqLg4Iarid2YMYyZ7pzjPeXKRvhW9nZqLo6kPBBTuvNET9DBVWptAo/Q20Fy11EIHM5ig4WlIrJfQw=="
+    crossorigin="anonymous" referrerpolicy="no-referrer" />
 {% endblock %}
 
 {% block content %}
-    {% include 'navigation.html' %}
-    <div class="container my-2">
-        {% include 'main/send_email_form.html' %}
+{% include 'navigation.html' %}
+<div class="container border-bottom my-2">
+    {% include 'main/send_email_form.html' %}
+</div>
+
+<div class="container">
+    <div class="accordion" id="email-accordion">
+
+        {% for email_recipients in emails.items %}
+        {% set email = email_recipients.email %}
+        {% set recipients = email_recipients.recipients %}
+        {% include 'main/email.html' %}
+        {% endfor %}
+
     </div>
 
-    <div class="container">
-        <div class="accordion" id="email-accordion">
-
-            {% for email_recipients in emails.items %}
-                {% set email = email_recipients.email %}
-                {% set recipients = email_recipients.recipients %}
-                {% include 'main/email.html' %}
-            {% endfor %}
-
-        </div>
-
-        {% set items = emails %}
-        {% include 'components/pagination.html' %}
-    </div>
+    {% set items = emails %}
+    {% include 'components/pagination.html' %}
+</div>
 
 
 {% endblock %}
 {% block scripts %}
-    <script
-        src="https://code.jquery.com/jquery-3.7.1.min.js"
-        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
-        crossorigin="anonymous">
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"
+    integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous">
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"
-        integrity="sha512-pF+DNRwavWMukUv/LyzDyDMn8U2uvqYQdJN0Zvilr6DDo/56xPDZdDoyPDYZRSL4aOKO/FGKXTpzDyQJ8je8Qw=="
-        crossorigin="anonymous" referrerpolicy="no-referrer">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"
+    integrity="sha512-pF+DNRwavWMukUv/LyzDyDMn8U2uvqYQdJN0Zvilr6DDo/56xPDZdDoyPDYZRSL4aOKO/FGKXTpzDyQJ8je8Qw=="
+    crossorigin="anonymous" referrerpolicy="no-referrer">
     </script>
-    <script>
-        document.addEventListener("DOMContentLoaded", () => {
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
 
-            let recipients = $("#recipients-input");
-            recipients.selectize({
-                valueField: "id",
-                labelField: "text",
-                searchField: ["text",
-                    {% for field in custom_fields %}
+        let recipients = $("#recipients-input");
+        recipients.selectize({
+            valueField: "id",
+            labelField: "text",
+            searchField: ["text",
+                {% for field in custom_fields %}
                         "{{field}}",
-                    {% endfor %}
+            {% endfor %}
                 ],
-                render: {
-                    option: function(item, escape) {
-                        let result = '<div class="border-bottom"><strong>' + escape(item.text) + '</strong>';
-                        result += '<br><small>';
-                        for (const field in item) {
-                            if (["text", "id", "$order"].includes(field)) {
-                                continue;
-                            }
-                            result += escape(field) + ': ' + escape(item[field]) + ' ';
-                        }
-                        result += '</small>';
-                        result += '</div>';
-                        return result
-                    }
-                },
-                options: [
-                    {% for group in groups %}
-                        {
-                            "id": "{{group.id}}",
-                            "text": "Группа: {{group.name}}",
-                        },
-                    {% endfor %}
-                    {% for recipient in recipients %}
-                        {% if recipient.unsubscribed_at %}{% continue %}{% endif %}
-                        {
-                            ...{
-                                "id": "{{recipient.email}}",
-                                "text": "{{recipient.name}} ({{recipient.email}})",
-                            },
-                            ...{{recipient.fields | json_encode() | safe}}
-                        },
-                    {% endfor %}
-                ],
-            });
-            let recipientsSelectize = recipients[0].selectize;
-
-            $(".recipientsDropDown").click(function(e) {
-                recipientsSelectize.focus();
-            });
-
-            $("#recipientsNone").click(function() {
-                recipientsSelectize.clear(false);
-            });
-
-            const form = document.getElementById('send-email-form');
-
-            const storageKey = 'savedMessageInput';
-            const saved = localStorage.getItem(storageKey);
-            const edit_message = document.getElementById('message-input');
-            if (saved !== null) {
-                edit_message.value = saved;
-                UpdateRenderedMessage();
+        render: {
+        option: function (item, escape) {
+            let result = '<div class="border-bottom"><strong>' + escape(item.text) + '</strong>';
+            result += '<br><small>';
+            for (const field in item) {
+                if (["text", "id", "$order"].includes(field)) {
+                    continue;
+                }
+                result += escape(field) + ': ' + escape(item[field]) + ' ';
             }
-            edit_message.addEventListener("input", function () {
-                localStorage.setItem(storageKey, edit_message.value);
+            result += '</small>';
+            result += '</div>';
+            return result
+        }
+    },
+        options: [
+        {% for group in groups %}
+    {
+        "id": "{{group.id}}",
+            "text": "Группа: {{group.name}}",
+                        },
+    {% endfor %}
+    {% for recipient in recipients %}
+    {% if recipient.unsubscribed_at %} {% continue %} {% endif %}
+    {
+                            ...{
+            "id": "{{recipient.email}}",
+                "text": "{{recipient.name}} ({{recipient.email}})",
+                            },
+                            ...{{ recipient.fields | json_encode() | safe }}
+    },
+    {% endfor %}
+                ],
             });
+    let recipientsSelectize = recipients[0].selectize;
 
-            form.addEventListener("submit", function (e) {
-                e.preventDefault();
-                const formData = new FormData(form);
-                formData.append('recipients', new Blob(
-                    [JSON.stringify(recipientsSelectize.items)],
-                    { type: 'application/json' }
-                ));
-                fetch(form.action, {
-                    method: form.method,
-                    body: formData,
-                    credentials: 'include'
-                })
-                .then(response => {
-                    return response.text();
-                })
-                .then(text => {
-                    const render_message = document.getElementById('message-rendered');
-                    form.reset();
-                    recipientsSelectize.clear(false);
-                    render_message.innerHTML = "";
-                    localStorage.removeItem(storageKey);
-                    showFlashMessage(text);
-                    setTimeout(() => {window.location.reload()}, 2000);
-                })
-                .catch(error => {
-                    console.error('Request error:', error);
-                    alert('An error occurred while sending the form: ' + error.message);
-                });
+    $(".recipientsDropDown").click(function (e) {
+        recipientsSelectize.focus();
+    });
+
+    $("#recipientsNone").click(function () {
+        recipientsSelectize.clear(false);
+    });
+
+    const form = document.getElementById('send-email-form');
+
+    const storageKey = 'savedMessageInput';
+    const saved = localStorage.getItem(storageKey);
+    const edit_message = document.getElementById('message-input');
+    if (saved !== null) {
+        edit_message.value = saved;
+        UpdateRenderedMessage();
+    }
+    edit_message.addEventListener("input", function () {
+        localStorage.setItem(storageKey, edit_message.value);
+    });
+
+    form.addEventListener("submit", function (e) {
+        e.preventDefault();
+        const formData = new FormData(form);
+        formData.append('recipients', new Blob(
+            [JSON.stringify(recipientsSelectize.items)],
+            { type: 'application/json' }
+        ));
+        fetch(form.action, {
+            method: form.method,
+            body: formData,
+            credentials: 'include'
+        })
+            .then(response => {
+                return response.text();
+            })
+            .then(text => {
+                const render_message = document.getElementById('message-rendered');
+                form.reset();
+                recipientsSelectize.clear(false);
+                render_message.innerHTML = "";
+                localStorage.removeItem(storageKey);
+                showFlashMessage(text);
+                setTimeout(() => { window.location.reload() }, 2000);
+            })
+            .catch(error => {
+                console.error('Request error:', error);
+                alert('An error occurred while sending the form: ' + error.message);
             });
+    });
 
         });
-    </script>
+</script>
 {% endblock %}

--- a/templates/main/send_email_form.html
+++ b/templates/main/send_email_form.html
@@ -1,35 +1,26 @@
-<form id="send-email-form" action="/send_email" method="POST" enctype="multipart/form-data">
-    <div class="row mb-3">
+<form id="send-email-form" action="/send_email" method="POST" enctype="multipart/form-data" class="mb-2">
+    <div class="row mb-1">
         <a class="recipientsDropDown" href="#">Получатели</a>
         <select id="recipients-input" multiple required>
             {% for recipient in retry.recipients | default(value=[]) %}
-                <option value="{{recipient.address}}" selected></option>
+            <option value="{{recipient.address}}" selected></option>
             {% endfor %}
         </select>
         <a id="recipientsNone" href="#" class="text-danger">убрать всех</a>
     </div>
     <div class="row">
         <div class="col">
-            <input type="text" name="subject" class="form-control my-1" placeholder="Тема" value="{{retry.email['subject'] | default(value='')}}">
-        </div>
-    </div>
-    <div class="row">
-        <div class="col">
-            <label class="form-label" for="cooldown-days-input">Не отправлять тем, кто получал письма последние (дней)</label>
-            <input
-                id="cooldown-days-input"
-                type="number"
-                min="0"
-                step="1"
-                name="cooldown_days"
-                class="form-control my-1"
-                value="{{ retry.email['cooldown_days'] | default(value='') }}"
-            >
+            <input type="text" name="subject" class="form-control mb-1" placeholder="Тема"
+                value="{{retry.email['subject'] | default(value='')}}">
         </div>
     </div>
     {% set message = retry.email['message'] | default(value='') %}
     {% include 'markdown.html' %}
     <div class="row">
+        <div class="col">
+            <input type="number" min="0" step="1" name="cooldown_days" class="form-control"
+                placeholder="фильтровать недавних получателей (дни)">
+        </div>
         <div class="col">
             <input class="form-control" type="file" name="attachment">
         </div>

--- a/tests/send_email_form.rs
+++ b/tests/send_email_form.rs
@@ -143,14 +143,24 @@ impl RecipientReader for CooldownRepository {
 }
 
 impl EmailRecipientReader for CooldownRepository {
-    fn list_recipients_grouped_by_address(
+    fn list_recent_recipients(
         &self,
-        _hub_id: i32,
+        hub_id: i32,
+        number_of_days: Option<i64>,
     ) -> RepositoryResult<Vec<EmailRecipient>> {
+        if hub_id != self.hub_id {
+            return Ok(vec![]);
+        }
+
+        let cutoff = number_of_days
+            .filter(|days| *days > 0)
+            .map(|days| Utc::now().naive_utc() - Duration::days(days));
+
         let recipients = self
             .history
             .iter()
             .enumerate()
+            .filter(|(_, entry)| cutoff.map(|cutoff| entry.sent_at > cutoff).unwrap_or(true))
             .map(|(index, entry)| EmailRecipient {
                 id: index as i32 + 1,
                 email_id: entry.email_id,


### PR DESCRIPTION
## Summary
- add a cooldown days field to the send email form template
- filter recipients that were emailed recently by consulting grouped recipient history
- extend repository stubs and tests to cover the new cooldown logic

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-features --tests -- -Dwarnings
- cargo build --all-features --verbose
- cargo test --all-features --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cfeacc18f8832aae0c9af71a8391aa